### PR TITLE
Move params to RequestMessage

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -26,7 +26,7 @@ module Scry
 
   SHUTDOWN_EXAMPLE = %({"jsonrpc":"2.0","id":1,"method":"shutdown"})
 
-  BUILD_ERROR_EXAMPLE = %({"file":"/home/aa.cr","line":4,"column":1,"size":1,"message":"Oh no!, an Error"})
+  BUILD_ERROR_EXAMPLE        = %({"file":"/home/aa.cr","line":4,"column":1,"size":1,"message":"Oh no!, an Error"})
   FORMATTER_RESPONSE_EXAMPLE =
     %({"jsonrpc":"2.0","result":[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":6}},"newText":"1 + 1"},{"range":{"start":{"line":1,"character":0},"end":{"line":2,"character":6}},"newText":""}]})
 

--- a/src/scry/formatter.cr
+++ b/src/scry/formatter.cr
@@ -21,7 +21,7 @@ module Scry
         new_lines = result.split('\n')
         old_lines = source.split('\n')
         max_line_num = [old_lines.size, new_lines.size].max # => max amount of lines
-        max_size = [source.size, result.size].max # => max amount of characters
+        max_size = [source.size, result.size].max           # => max amount of characters
         text_edits = new_lines.map_with_index do |line_data, line_num|
           # Ensure to replace all old document
           if line_num == new_lines.size - 1

--- a/src/scry/protocol/initialize_params.cr
+++ b/src/scry/protocol/initialize_params.cr
@@ -8,6 +8,5 @@ module Scry
       capabilities: JSON::Any,
       trace:        String?,
     })
-
   end
 end

--- a/src/scry/protocol/notification_message.cr
+++ b/src/scry/protocol/notification_message.cr
@@ -12,8 +12,6 @@ module Scry
                             DidChangeTextDocumentParams |
                             DidChangeWatchedFilesParams |
                             DidOpenTextDocumentParams |
-                            DocumentFormattingParams |
-                            TextDocumentPositionParams |
                             PublishDiagnosticsParams |
                             Trace)
 

--- a/src/scry/protocol/request_message.cr
+++ b/src/scry/protocol/request_message.cr
@@ -2,11 +2,15 @@ require "./initialize_params"
 
 module Scry
   struct RequestMessage
+    alias RequestType = (TextDocumentPositionParams |
+                         InitializeParams |
+                         DocumentFormattingParams)?
+
     JSON.mapping({
       jsonrpc: String,
       id:      Int32,
       method:  String,
-      params:  InitializeParams?,
+      params:  RequestType,
     })
   end
 end


### PR DESCRIPTION
It seems a couple of the Params are in the wrong MessageType.

Based on the LSP 3.0 Spec the [`TextDocumentPositionParams`](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#textdocumentpositionparams)  and [`DocumentFormattingParams`](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#document-formatting-request) are associated with Request Messages

