### PR TITLE
Remove id from NotificationMessage

### DIFF
--- a/src/scry/protocol/notification_message.cr
+++ b/src/scry/protocol/notification_message.cr
@@ -18,7 +18,6 @@ module Scry
   struct NotificationMessage
     JSON.mapping({
       jsonrpc: String,
-      id:      Int32?,
       method:  String,
       params:  NotificationType,
     }, true)


### PR DESCRIPTION
According to LSP 3.0 spec regarding [NotificationMessages](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#notification-message) the id field is not part of the spec.  This PR removes the optional id from the NotificationMessage type