### PR TITLE
Move didSave/didClose messages to Notifications

### DIFF
--- a/spec/scry/message_spec.cr
+++ b/spec/scry/message_spec.cr
@@ -21,5 +21,15 @@ module Scry
       procedure = Message.new(SHUTDOWN_EXAMPLE).parse
       procedure.is_a?(RequestMessage).should be_true
     end
+
+    it "creates a didSave notification" do
+      procedure = Message.new(DID_SAVE_EXAMPLE).parse
+      procedure.is_a?(NotificationMessage).should be_true
+    end
+
+    it "creates a didClose notification" do
+      procedure = Message.new(DOC_CLOSE_EXAMPLE).parse
+      procedure.is_a?(NotificationMessage).should be_true
+    end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -12,7 +12,11 @@ module Scry
 
   DOC_OPEN_EXAMPLE = %({"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///Users/foo/Projects/crystal_av/src/crystal_av/c_handler.cr","languageId":"crystal","version":1,"text":"put \\"hello\\"; Thing.new"}}})
 
+  DOC_CLOSE_EXAMPLE = %({"jsonrpc":"2.0","method":"textDocument/didClose","params":{"textDocument":{ "uri":"file://#{SOME_FILE_PATH}" }}})
+
   DOC_CHANGE_EXAMPLE = %({"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"version":808,"uri":"file://#{SOME_FILE_PATH}"},"contentChanges":[{"text":"module Scry\\n\\n  put this\\n"}]}})
+
+  DID_SAVE_EXAMPLE = %({"jsonrpc":"2.0","method":"textDocument/didSave","params":{"textDocument":{ "uri":"file://#{SOME_FILE_PATH}" }}})
 
   WATCHED_FILE_CHANGED_EXAMPLE = %({"jsonrpc":"2.0","method":"workspace/didChangeWatchedFiles","params":{"changes":[{"uri":"file://#{SOME_FILE_PATH}","type":2}]}})
 

--- a/src/scry/context.cr
+++ b/src/scry/context.cr
@@ -45,10 +45,6 @@ module Scry
     # Also used by methods like Go to Definition
     private def dispatchRequest(params : TextDocumentPositionParams, msg)
       case msg.method
-      when "textDocument/didSave"
-        nil
-      when "textDocument/didClose"
-        nil
       when "textDocument/definition"
         text_document = TextDocument.new(params, msg.id)
         definitions = Implementations.new(text_document)
@@ -69,6 +65,13 @@ module Scry
         Log.logger.debug(response)
         response
       end
+    end
+
+    # Used by:
+    # - `textDocument/didSave`
+    # - `textDocument/didClose`
+    private def dispatchNotification(params : TextDocumentParams, msg)
+      nil
     end
 
     private def dispatchNotification(params : DidChangeConfigurationParams, msg)

--- a/src/scry/protocol/notification_message.cr
+++ b/src/scry/protocol/notification_message.cr
@@ -2,8 +2,8 @@ require "./did_change_configuration_params"
 require "./did_change_text_document_params"
 require "./did_change_watched_files_params"
 require "./did_open_text_document_params"
+require "./text_document_params"
 require "./document_formatting_params"
-require "./text_document_position_params"
 require "./publish_diagnostics_params"
 require "./trace"
 
@@ -12,6 +12,7 @@ module Scry
                             DidChangeTextDocumentParams |
                             DidChangeWatchedFilesParams |
                             DidOpenTextDocumentParams |
+                            TextDocumentParams |
                             PublishDiagnosticsParams |
                             Trace)
 

--- a/src/scry/protocol/request_message.cr
+++ b/src/scry/protocol/request_message.cr
@@ -1,4 +1,5 @@
 require "./initialize_params"
+require "./text_document_position_params"
 
 module Scry
   struct RequestMessage

--- a/src/scry/protocol/text_document_params.cr
+++ b/src/scry/protocol/text_document_params.cr
@@ -1,0 +1,12 @@
+require "json"
+require "./text_document_identifier"
+require "./versioned_text_document_identifier"
+
+module Scry
+  struct TextDocumentParams
+    JSON.mapping({
+      text_document: {type: (TextDocumentIdentifier | VersionedTextDocumentIdentifier), key: "textDocument"},
+      text:          String?,
+    }, true)
+  end
+end

--- a/src/scry/protocol/text_document_position_params.cr
+++ b/src/scry/protocol/text_document_position_params.cr
@@ -5,7 +5,7 @@ module Scry
   struct TextDocumentPositionParams
     JSON.mapping({
       text_document: {type: TextDocumentIdentifier, key: "textDocument"},
-      position:      Position?,
+      position:      Position,
     }, true)
   end
 end


### PR DESCRIPTION
Fixes a couple message types

- Moves didSave/didClose notifications to Notification messages type
- Makes didSave v3 compliant
- Creates generic `TextDocumentParams` params struct that contains a `TextDocumentIdentifer` or `VersionedTextDocumentIdentifier` and optional fields
- Makes `TextDocumentPositionParams` explicit