### PR TITLE
Adds initialized notification

### DIFF
--- a/spec/scry/message_spec.cr
+++ b/spec/scry/message_spec.cr
@@ -31,5 +31,10 @@ module Scry
       procedure = Message.new(DOC_CLOSE_EXAMPLE).parse
       procedure.is_a?(NotificationMessage).should be_true
     end
+
+    it "creates a initialized notification" do
+      procedure = Message.new(INITIALIZED_EXAMPLE).parse
+      procedure.is_a?(NotificationMessage).should be_true
+    end
   end
 end

--- a/spec/scry/protocol/void_params_spec.cr
+++ b/spec/scry/protocol/void_params_spec.cr
@@ -1,0 +1,21 @@
+require "../../spec_helper"
+
+module Scry
+  describe VoidParams do
+    it "creates from json" do
+      void_params = VoidParams.from_json("{}")
+      void_params.is_a?(VoidParams).should be_true
+    end
+
+    it "raises a JSON::ParseException if non empty JSON is supplied" do
+      expect_raises(JSON::ParseException) do
+        void_params = VoidParams.from_json(%({ "key": "value" }))
+      end
+    end
+
+    it "will render as JSON" do
+      void_params = VoidParams.from_json("{}")
+      void_params.to_json.should eq("{}")
+    end
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -29,4 +29,6 @@ module Scry
   FORMATTER_RESPONSE_EXAMPLE = %({"jsonrpc":"2.0","result":[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":6}},"newText":"1 + 1"},{"range":{"start":{"line":1,"character":0},"end":{"line":2,"character":6}},"newText":""}]})
 
   TEXTDOCUMENT_POSITION_PARAM_EXAMPLE = %({"textDocument":{"uri":"#{SOME_FILE_PATH}"},"position":{"line":4,"character":2}})
+
+  INITIALIZED_EXAMPLE = %({"jsonrpc": "2.0", "method": "initialized", "params": {}})
 end

--- a/src/scry/context.cr
+++ b/src/scry/context.cr
@@ -131,5 +131,9 @@ module Scry
     private def dispatchNotification(params : PublishDiagnosticsParams, msg)
       nil
     end
+
+    private def dispatchNotification(params : VoidParams, msg)
+      nil
+    end
   end
 end

--- a/src/scry/protocol/notification_message.cr
+++ b/src/scry/protocol/notification_message.cr
@@ -5,6 +5,7 @@ require "./did_open_text_document_params"
 require "./text_document_params"
 require "./document_formatting_params"
 require "./publish_diagnostics_params"
+require "./void_params"
 require "./trace"
 
 module Scry
@@ -14,6 +15,7 @@ module Scry
                             DidOpenTextDocumentParams |
                             TextDocumentParams |
                             PublishDiagnosticsParams |
+                            VoidParams |
                             Trace)
 
   struct NotificationMessage

--- a/src/scry/protocol/void_params.cr
+++ b/src/scry/protocol/void_params.cr
@@ -1,0 +1,14 @@
+require "json"
+
+module Scry
+  struct VoidParams
+    def initialize(pull : JSON::PullParser)
+      pull.read_begin_object
+      pull.read_end_object
+    end
+
+    def to_json(json : ::JSON::Builder)
+      json.object { nil }
+    end
+  end
+end


### PR DESCRIPTION
Allows Scry to receive the [initialized notification](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#initialized). 

Adds new param type `VoidParams` which is an empty JSON object used by the initialized notification