### PR TITLE
Send back single formatted TextEdit

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -26,7 +26,7 @@ module Scry
 
   BUILD_ERROR_EXAMPLE = %({"file":"/home/aa.cr","line":4,"column":1,"size":1,"message":"Oh no!, an Error"})
 
-  FORMATTER_RESPONSE_EXAMPLE = %({"jsonrpc":"2.0","result":[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":6}},"newText":"1 + 1"},{"range":{"start":{"line":1,"character":0},"end":{"line":2,"character":6}},"newText":""}]})
+  FORMATTER_RESPONSE_EXAMPLE = %({"jsonrpc":"2.0","result":[{"range":{"start":{"line":0,"character":0},"end":{"line":1,"character":6}},"newText":"1 + 1\\n"}]})
 
   TEXTDOCUMENT_POSITION_PARAM_EXAMPLE = %({"textDocument":{"uri":"#{SOME_FILE_PATH}"},"position":{"line":4,"character":2}})
 

--- a/src/scry/formatter.cr
+++ b/src/scry/formatter.cr
@@ -18,24 +18,15 @@ module Scry
     private def format(source)
       result = Crystal.format(source)
       unless source == result
-        new_lines = result.split('\n')
         old_lines = source.split('\n')
-        max_line_num = [old_lines.size, new_lines.size].max # => max amount of lines
-        max_size = [source.size, result.size].max           # => max amount of characters
-        text_edits = new_lines.map_with_index do |line_data, line_num|
-          # Ensure to replace all old document
-          if line_num == new_lines.size - 1
-            line_num_end = max_line_num
-          else
-            line_num_end = line_num
-          end
-          range = Range.new(
-            Position.new(line_num, 0),
-            Position.new(line_num_end, max_size) # => Max column posible to replace old column
-          )
-          TextEdit.new(range, line_data)
-        end
-        ResponseMessage.new(@text_document.id, text_edits)
+        max_size = [source.size, result.size].max # => max amount of characters
+
+        range = Range.new(
+          Position.new(0, 0),
+          Position.new(old_lines.size, max_size) # => Max column posible to replace old column
+        )
+
+        ResponseMessage.new(@text_document.id, [TextEdit.new(range, result)])
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/crystal-lang-tools/scry/issues/35

- Formats document with a single TextEdit rather than many since we end up formatting the entire source anyway