### PR TITLE
Symbol Initial Implementation

### DIFF
--- a/spec/scry/response_spec.cr
+++ b/spec/scry/response_spec.cr
@@ -38,7 +38,7 @@ module Scry
       io = IO::Memory.new
       response = Response.new(results)
       response.write(io)
-      io.to_s.should eq(%(Content-Length: 134\r\n\r\n{"jsonrpc":"2.0","id":32,"result":{"capabilities":{"textDocumentSync":1,"documentFormattingProvider":true,"definitionProvider":true}}}))
+      io.to_s.should eq(%(Content-Length: 164\r\n\r\n{"jsonrpc":"2.0","id":32,"result":{"capabilities":{"textDocumentSync":1,"documentFormattingProvider":true,"definitionProvider":true,"documentSymbolProvider":true}}}))
     end
   end
 end

--- a/spec/scry/symbol_spec.cr
+++ b/spec/scry/symbol_spec.cr
@@ -1,0 +1,50 @@
+require "../spec_helper"
+
+module Scry
+  describe SymbolProcessor do
+    it "returns a ResponseMessage" do
+      text_document = TextDocument.new("inmemory://model/3", [""])
+      processor = SymbolProcessor.new(text_document)
+      processor.run.is_a?(ResponseMessage).should be_true
+    end
+
+    it "contains SymbolInformation" do
+      text_document = TextDocument.new("uri", [""])      
+      processor = SymbolProcessor.new(text_document)
+      response = processor.run
+      response.result.is_a?(Array(SymbolInformation)).should be_true
+    end
+
+    it "returns Class symbols" do
+      text_document = TextDocument.new("uri", ["class Test; end"])      
+      processor = SymbolProcessor.new(text_document)
+      response = processor.run
+      result = response.result.try(&.first)
+      result.as(SymbolInformation).kind.is_a?(SymbolKind::Class).should be_true
+    end
+
+    it "returns Struct symbols as a Class" do
+      text_document = TextDocument.new("uri", ["struct Test; end"])      
+      processor = SymbolProcessor.new(text_document)
+      response = processor.run
+      result = response.result.try(&.first)
+      result.as(SymbolInformation).kind.is_a?(SymbolKind::Class).should be_true
+    end
+
+    it "returns Module symbols" do
+      text_document = TextDocument.new("uri", ["module Test; end"])      
+      processor = SymbolProcessor.new(text_document)
+      response = processor.run
+      result = response.result.try(&.first)
+      result.as(SymbolInformation).kind.is_a?(SymbolKind::Module).should be_true
+    end
+
+    it "returns Method symbols" do
+      text_document = TextDocument.new("uri", ["def test; end"])      
+      processor = SymbolProcessor.new(text_document)
+      response = processor.run
+      result = response.result.try(&.first)
+      result.as(SymbolInformation).kind.is_a?(SymbolKind::Method).should be_true
+    end
+  end
+end

--- a/src/scry/context.cr
+++ b/src/scry/context.cr
@@ -6,6 +6,7 @@ require "./implementations"
 require "./update_config"
 require "./parse_analyzer"
 require "./publish_diagnostic"
+require "./symbol"
 
 module Scry
   class UnrecognizedProcedureError < Exception
@@ -62,6 +63,17 @@ module Scry
       unless text_document.untitled?
         formatter = Formatter.new(@workspace, text_document)
         response = formatter.run
+        Log.logger.debug(response)
+        response
+      end
+    end
+
+    private def dispatchRequest(params : TextDocumentParams, msg)
+      case msg.method
+      when "textDocument/documentSymbol"
+        text_document = TextDocument.new(params, msg.id)
+        symbol_processor = SymbolProcessor.new(text_document)
+        response = symbol_processor.run
         Log.logger.debug(response)
         response
       end

--- a/src/scry/protocol/request_message.cr
+++ b/src/scry/protocol/request_message.cr
@@ -5,7 +5,8 @@ module Scry
   struct RequestMessage
     alias RequestType = (TextDocumentPositionParams |
                          InitializeParams |
-                         DocumentFormattingParams)?
+                         DocumentFormattingParams |
+                         TextDocumentParams)?
 
     JSON.mapping({
       jsonrpc: String,

--- a/src/scry/protocol/response_message.cr
+++ b/src/scry/protocol/response_message.cr
@@ -1,10 +1,11 @@
 require "./response_error"
 require "./text_edit"
 require "./location"
+require "./symbol_information"
 
 module Scry
   # Add a response type when needed
-  alias ResponseTypes = Array(TextEdit) | Array(Location)
+  alias ResponseTypes = Array(TextEdit) | Array(Location) | Array(SymbolInformation)
 
   struct ResponseMessage
     JSON.mapping({

--- a/src/scry/protocol/server_capabilities.cr
+++ b/src/scry/protocol/server_capabilities.cr
@@ -31,13 +31,15 @@ module Scry
     JSON.mapping(
       textDocumentSync: TextDocumentSyncKind,
       documentFormattingProvider: Bool,
-      definitionProvider: Bool
+      definitionProvider: Bool,
+      documentSymbolProvider: Bool
     )
 
     def initialize
       @textDocumentSync = TextDocumentSyncKind::Full
       @documentFormattingProvider = true
       @definitionProvider = true
+      @documentSymbolProvider = true
     end
   end
 end

--- a/src/scry/protocol/symbol_information.cr
+++ b/src/scry/protocol/symbol_information.cr
@@ -1,0 +1,37 @@
+require "json"
+require "./location"
+
+module Scry
+  enum SymbolKind
+    File        =  1
+    Module      =  2
+    Namespace   =  3
+    Package     =  4
+    Class       =  5
+    Method      =  6
+    Property    =  7
+    Field       =  8
+    Constructor =  9
+    Enum        = 10
+    Interface   = 11
+    Function    = 12
+    Variable    = 13
+    Constant    = 14
+    String      = 15
+    Number      = 16
+    Boolean     = 17
+    Array       = 18
+  end
+
+  struct SymbolInformation
+    JSON.mapping({
+      name:          String,
+      kind:          SymbolKind,
+      location:      Location,
+      containerName: String?,
+    }, true)
+
+    def initialize(@name, @kind, @location, @containerName = Nil)
+    end
+  end
+end

--- a/src/scry/symbol.cr
+++ b/src/scry/symbol.cr
@@ -1,0 +1,96 @@
+require "compiler/crystal/syntax"
+
+module Scry
+  class SymbolVisitor < Crystal::Visitor
+    getter symbols
+
+    def initialize(@document_uri : String)
+      @container = [] of String
+      @symbols = [] of SymbolInformation
+    end
+
+    def visit(node : Crystal::ClassDef)
+      process_node node, node.name.names.last, SymbolKind::Class
+      @container << node.name.names.last
+      true
+    end
+
+    def visit(node : Crystal::EnumDef)
+      process_node node, node.name.names.last, SymbolKind::Enum
+      @container << node.name.names.last
+      true
+    end
+
+    def visit(node : Crystal::ModuleDef)
+      process_node node, node.name.names.last, SymbolKind::Module
+      @container << node.name.names.last
+      true
+    end
+
+    def visit(node : Crystal::Def)
+      process_node node, node.name, SymbolKind::Method
+      false
+    end
+
+    def visit(node : Crystal::LibDef)
+      process_node node, node.name, SymbolKind::Package
+      @container << node.name
+      true
+    end
+
+    def visit(node : Crystal::StructOrUnionDef)
+      process_node node, node.name, SymbolKind::Class
+      @container << node.name
+      true
+    end
+
+    def visit(node : Crystal::FunDef)
+      process_node node, node.name, SymbolKind::Function
+      true
+    end
+
+    def visit(node : Crystal::Expressions)
+      true
+    end
+
+    def visit(node : Crystal::ASTNode)
+      true
+    end
+
+    def end_visit(node : Crystal::ClassDef | Crystal::ModuleDef | Crystal::CStructOrUnionDef | Crystal::LibDef | Crystal::EnumDef)
+      return unless node.location
+      @container.pop?
+    end
+
+    def process_node(node, name : String, kind : SymbolKind)
+      location = node.location
+      return true unless location
+
+      line_number = location.line_number
+      column_number = location.column_number
+
+      position = Position.new(line_number - 1, column_number - 1)
+      range = Range.new(position, position)
+      location = Location.new(@document_uri, range)
+
+      @symbols << SymbolInformation.new(name, kind, location, @container.join("::"))
+
+      true
+    end
+  end
+
+  class SymbolProcessor
+    def initialize(@text_document : TextDocument)
+    end
+
+    def run
+      visitor = SymbolVisitor.new(@text_document.uri)
+      parser = Crystal::Parser.new(@text_document.source)
+      parser.filename = @text_document.filename
+      node = parser.parse
+      node.accept(visitor)
+
+      ResponseMessage.new(@text_document.id, visitor.symbols)
+    end
+  end
+end

--- a/src/scry/text_document.cr
+++ b/src/scry/text_document.cr
@@ -54,6 +54,12 @@ module Scry
       @text = [read_file]
     end
 
+    def initialize(params : TextDocumentParams, @id)
+      @uri = params.text_document.uri
+      @filename = uri_to_filename
+      @text = [read_file]
+    end
+
     def uri_to_filename
       @uri.sub(/^file:\/\/|^inmemory:\/\/|^git:\/\//, "")
     end
@@ -64,6 +70,10 @@ module Scry
 
     def untitled?
       uri.starts_with?("untitled:")
+    end
+
+    def source
+      @text.first
     end
 
     private def read_file : String


### PR DESCRIPTION
Based on https://github.com/crystal-lang-tools/scry/issues/38

This implements initial Symbol support for Scry.  I originally started to use `CrystalCtags` but feel that was kind of written to do something similar but not exactly the same.  Some changes would needed to be made to Ctags in order for it to work for Scry's purposes I believe, and it might just be easier to have our own implementation.

This PR adds a Scry specific `SymbolVisitor` which  traverses the AST and builds a list of Symbols to be sent as the response.  I have only added support for Class/Module/Enum/Struct/Methods in this initial PR.  Let me know what you think and if you think this is a good way to proceed!
