### PR TITLE
Add property and variable symbols

### DIFF
--- a/spec/scry/symbol_spec.cr
+++ b/spec/scry/symbol_spec.cr
@@ -9,14 +9,14 @@ module Scry
     end
 
     it "contains SymbolInformation" do
-      text_document = TextDocument.new("uri", [""])      
+      text_document = TextDocument.new("uri", [""])
       processor = SymbolProcessor.new(text_document)
       response = processor.run
       response.result.is_a?(Array(SymbolInformation)).should be_true
     end
 
     it "returns Class symbols" do
-      text_document = TextDocument.new("uri", ["class Test; end"])      
+      text_document = TextDocument.new("uri", ["class Test; end"])
       processor = SymbolProcessor.new(text_document)
       response = processor.run
       result = response.result.try(&.first)
@@ -24,7 +24,7 @@ module Scry
     end
 
     it "returns Struct symbols as a Class" do
-      text_document = TextDocument.new("uri", ["struct Test; end"])      
+      text_document = TextDocument.new("uri", ["struct Test; end"])
       processor = SymbolProcessor.new(text_document)
       response = processor.run
       result = response.result.try(&.first)
@@ -32,7 +32,7 @@ module Scry
     end
 
     it "returns Module symbols" do
-      text_document = TextDocument.new("uri", ["module Test; end"])      
+      text_document = TextDocument.new("uri", ["module Test; end"])
       processor = SymbolProcessor.new(text_document)
       response = processor.run
       result = response.result.try(&.first)
@@ -40,16 +40,50 @@ module Scry
     end
 
     it "returns Method symbols" do
-      text_document = TextDocument.new("uri", ["def test; end"])      
+      text_document = TextDocument.new("uri", ["def test; end"])
       processor = SymbolProcessor.new(text_document)
       response = processor.run
       result = response.result.try(&.first)
       result.as(SymbolInformation).kind.is_a?(SymbolKind::Method).should be_true
     end
 
+    it "returns instance vars as Variable symbols" do
+      text_document = TextDocument.new("uri", ["@bar = nil"])
+      processor = SymbolProcessor.new(text_document)
+      response = processor.run
+      result = response.result.try(&.first)
+      result.as(SymbolInformation).kind.is_a?(SymbolKind::Variable).should be_true
+    end
+
+    describe "Property" do
+      it "returns getters as Property symbols" do
+        text_document = TextDocument.new("uri", ["class Foo; getter bar : Nil; end"])
+        processor = SymbolProcessor.new(text_document)
+        response = processor.run
+        result = response.result.try { |r| r[1] }
+        result.as(SymbolInformation).kind.is_a?(SymbolKind::Property).should be_true
+      end
+
+      it "returns setters as Property symbols" do
+        text_document = TextDocument.new("uri", ["class Foo; setter bar : Nil; end"])
+        processor = SymbolProcessor.new(text_document)
+        response = processor.run
+        result = response.result.try { |r| r[1] }
+        result.as(SymbolInformation).kind.is_a?(SymbolKind::Property).should be_true
+      end
+
+      it "returns properties as Property symbols" do
+        text_document = TextDocument.new("uri", ["class Foo; property bar : Nil; end"])
+        processor = SymbolProcessor.new(text_document)
+        response = processor.run
+        result = response.result.try { |r| r[1] }
+        result.as(SymbolInformation).kind.is_a?(SymbolKind::Property).should be_true
+      end
+    end
+
     describe "Constants" do
       it "returns Constant symbols" do
-        text_document = TextDocument.new("uri", [%(HELLO = "world")])      
+        text_document = TextDocument.new("uri", [%(HELLO = "world")])
         processor = SymbolProcessor.new(text_document)
         response = processor.run
         result = response.result.try(&.first)
@@ -57,7 +91,7 @@ module Scry
       end
 
       it "returns alias as Constant symbols" do
-        text_document = TextDocument.new("uri", [%(alias Hello = World)])      
+        text_document = TextDocument.new("uri", [%(alias Hello = World)])
         processor = SymbolProcessor.new(text_document)
         response = processor.run
         result = response.result.try(&.first)

--- a/src/scry/symbol.cr
+++ b/src/scry/symbol.cr
@@ -48,7 +48,7 @@ module Scry
       process_node node, node.name, SymbolKind::Function
       true
     end
-    
+
     def visit(node : Crystal::Alias)
       process_node node, node.name, SymbolKind::Constant
       true
@@ -66,6 +66,16 @@ module Scry
     end
 
     def visit(node : Crystal::ASTNode)
+      true
+    end
+
+    def visit(node : Crystal::Var)
+      process_node node, node.name, SymbolKind::Property
+      true
+    end
+
+    def visit(node : Crystal::InstanceVar)
+      process_node node, node.name, SymbolKind::Variable
       true
     end
 


### PR DESCRIPTION
Adds property and variable symbols to Scry, in line with how `vscode-crystal-lang` defines them.

Related to #38 