### PR TITLE
Make scry faster and lightweight

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
         - DEPLOY_DIR=bin/darwin
 
 install:
-  - bin/ci  prepare_build
+  - bin/ci prepare_build
 
 script:
   - bin/ci build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM crystallang/crystal:0.24.1
 
 RUN apt-get update
-RUN apt-get install -y llvm-4.0-dev
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Scry will be distributed as part of editors extensions, see:
 
 ## Development && Roadmap
 
-> **Note:** crystal and LLVM are required in order to compile scry.
+> **Note:** crystal is required in order to compile scry.
 
 Ongoing, in [our](https://github.com/kofno/scry#contributors) free time.
 

--- a/bin/ci
+++ b/bin/ci
@@ -65,8 +65,7 @@ prepare_build() {
   on_linux docker build -t crystal/scry-image .
 
   on_osx brew update
-  on_osx brew install llvm crystal-lang
-  on_osx brew link --overwrite --force llvm
+  on_osx brew install crystal-lang
 }
 
 

--- a/spec/scry/initialize_spec.cr
+++ b/spec/scry/initialize_spec.cr
@@ -6,7 +6,7 @@ module Scry
       initer = Initializer.new(
         InitializeParams.from_json({
           processId:    1,
-          rootPath:     "/homa/main/Projects/Experiment",
+          rootPath:     "/home/main/Projects/Experiment",
           capabilities: {} of String => String,
           trace:        "off",
         }.to_json),

--- a/src/scry/analyzer.cr
+++ b/src/scry/analyzer.cr
@@ -39,7 +39,7 @@ module Scry
     private def crystal_build(filename, source)
       code = IO::Memory.new(source)
       String.build do |io|
-        Process.run("crystal", ["build", "--no-color", "--error-trace", "-f", "json", filename], output: io, error: io, input: code)
+        Process.run("crystal", ["build", "--no-codegen", "--no-color", "--error-trace", "-f", "json", "--stdin-filename", filename], output: io, error: io, input: code)
       end
     end
   end

--- a/src/scry/missing_methods.cr
+++ b/src/scry/missing_methods.cr
@@ -1,0 +1,17 @@
+# HACK: to avoid requiring the whole compiler
+module Crystal
+  struct CrystalPath
+    class Error
+      def to_s_with_source(source, io)
+      end
+    end
+  end
+
+  class Exception
+    def to_json_single(json)
+      json.object do
+        json.field "message", @message
+      end
+    end
+  end
+end

--- a/src/scry/parse_analyzer.cr
+++ b/src/scry/parse_analyzer.cr
@@ -1,8 +1,9 @@
-require "compiler/crystal/**"
-
+require "compiler/crystal/syntax"
+require "compiler/crystal/crystal_path"
 require "./workspace"
 require "./text_document"
 require "./publish_diagnostic"
+require "./missing_methods"
 
 module Scry
   struct ParseAnalyzer
@@ -20,7 +21,7 @@ module Scry
       parser.parse
       [@diagnostic.clean]
     rescue ex : Crystal::Exception
-      @diagnostic.from(ex)
+      @diagnostic.from(ex.to_json)
     end
   end
 end

--- a/src/scry/publish_diagnostic.cr
+++ b/src/scry/publish_diagnostic.cr
@@ -26,7 +26,7 @@ module Scry
     end
 
     def from(ex)
-      build_failures = Array(BuildFailure).from_json(ex.to_json)
+      build_failures = Array(BuildFailure).from_json(ex)
       build_failures
         .uniq
         .first(@workspace.max_number_of_problems)


### PR DESCRIPTION
Hi, this PR implements lightweight features:

- Lightweight analyzer and implementations
- Avoid heavy compiler dependencies
- Use external process to free up memory

Before:

![screenshot_20180304_083813](https://user-images.githubusercontent.com/3067335/36946216-614f70b2-1f87-11e8-8946-cc15132937b2.png)

With this PR changes:

![screenshot_20180304_083640](https://user-images.githubusercontent.com/3067335/36946201-2a0cfd68-1f87-11e8-9322-9f3635e0318f.png)

Same features and behaviors, more RAM friendly and lightweight binary `19.2MB` vs `4.7MB`

Oh, also compilation time has been reduced drastically:

```
$ time crystal build src/scry.cr -s -p --no-debug
Parse:                             00:00:00.000316202 (   0.25MB)
Semantic (top level):              00:00:00.404959721 (  52.33MB)
Semantic (new):                    00:00:00.002962556 (  52.33MB)
Semantic (type declarations):      00:00:00.032710793 (  52.33MB)
Semantic (abstract def check):     00:00:00.002463025 (  52.33MB)
Semantic (ivars initializers):     00:00:00.001851865 (  52.33MB)
Semantic (cvars initializers):     00:00:00.240542928 (  68.33MB)
Semantic (main):                   00:00:01.663311243 ( 196.77MB)
Semantic (cleanup):                00:00:00.006314623 ( 196.77MB)
Semantic (recursive struct check): 00:00:00.002034422 ( 196.77MB)
Codegen (crystal):                 00:00:01.197870686 ( 228.77MB)
Codegen (bc+obj):                  00:00:05.765841086 ( 228.77MB)
Codegen (linking):                 00:00:00.761140190 ( 228.77MB)
                                          
Codegen (bc+obj):
 - no previous .o files were reused
crystal build src/scry.cr -s -p --no-debug  14.42s user 0.81s system 149% cpu 10.159 total
```

Previously scry compilation used a huge amout of RAM (above 1GB) and took several minutes to compile in my pc :sweat: 

Fixes #30

Related comment on https://github.com/crystal-lang-tools/scry/pull/48#issuecomment-370222717