### PR TITLE
Allow formatting unsaved document

### DIFF
--- a/src/scry/context.cr
+++ b/src/scry/context.cr
@@ -69,12 +69,14 @@ module Scry
     private def dispatchRequest(params : DocumentFormattingParams, msg)
       text_document = TextDocument.new(params, msg.id)
 
-      unless text_document.untitled?
-        formatter = Formatter.new(@workspace, text_document)
-        response = formatter.run
-        Log.logger.debug(response)
-        response
+      if open_file = @workspace.open_files.first_value?
+        text_document.text = open_file.text
       end
+
+      formatter = Formatter.new(@workspace, text_document)
+      response = formatter.run
+      Log.logger.debug(response)
+      response
     end
 
     private def dispatchRequest(params : TextDocumentParams, msg)

--- a/src/scry/context.cr
+++ b/src/scry/context.cr
@@ -69,7 +69,7 @@ module Scry
     private def dispatchRequest(params : DocumentFormattingParams, msg)
       text_document = TextDocument.new(params, msg.id)
 
-      if open_file = @workspace.open_files.first_value?
+      if open_file = @workspace.open_files[text_document.filename]
         text_document.text = open_file.text
       end
 

--- a/src/scry/context.cr
+++ b/src/scry/context.cr
@@ -69,7 +69,7 @@ module Scry
     private def dispatchRequest(params : DocumentFormattingParams, msg)
       text_document = TextDocument.new(params, msg.id)
 
-      if open_file = @workspace.open_files[text_document.filename]
+      if open_file = @workspace.open_files[text_document.filename]?
         text_document.text = open_file.text
       end
 

--- a/src/scry/formatter.cr
+++ b/src/scry/formatter.cr
@@ -28,6 +28,9 @@ module Scry
 
         ResponseMessage.new(@text_document.id, [TextEdit.new(range, result)])
       end
+    rescue ex
+      Log.logger.error("A error was found while formatting\n#{ex}")
+      nil
     end
   end
 end

--- a/src/scry/text_document.cr
+++ b/src/scry/text_document.cr
@@ -40,11 +40,7 @@ module Scry
     def initialize(params : DocumentFormattingParams, @id)
       @uri = params.text_document.uri
       @filename = uri_to_filename
-      if untitled?
-        @text = [""]
-      else
-        @text = [read_file]
-      end
+      @text = [""]
     end
 
     def initialize(params : TextDocumentPositionParams, @id)

--- a/src/scry/text_document.cr
+++ b/src/scry/text_document.cr
@@ -10,8 +10,8 @@ module Scry
     getter id : Int32 | Nil
     getter uri : String
     getter filename : String
-    getter text : Array(String)
     getter position : Position?
+    property text : Array(String)
 
     def initialize(@uri, @text)
       @filename = uri_to_filename


### PR DESCRIPTION
Currently scry can't format an unsaved document, with this PR now you can format even a untitled file :tada: 

![ezgif-2-db8399697c](https://user-images.githubusercontent.com/3067335/36947407-19447fc6-1f99-11e8-89ab-11182f044d84.gif)

/cc @crystal-lang-tools/scry 