### PR TITLE
Allow not found implementation

### DIFF
--- a/src/scry/implementations.cr
+++ b/src/scry/implementations.cr
@@ -29,6 +29,8 @@ module Scry
           Location.new("file://" + impl["filename"].as_s, range)
         end
         ResponseMessage.new(@text_document.id, locations)
+      else
+        ResponseMessage.new(@text_document.id, [] of Location)
       end
     rescue ex
       Log.logger.error("A error was found while searching definitions\n#{ex}")

--- a/src/scry/protocol/diagnostic.cr
+++ b/src/scry/protocol/diagnostic.cr
@@ -43,7 +43,7 @@ module Scry
         Position.new(line - 1, column + size - 1)
       )
       @severity = DiagnosticSeverity::Error.value
-      @source = "Scry [Crystal]"
+      @source = "Scry"
     end
   end
 end


### PR DESCRIPTION
Currently if an implementation isn't found the editor keeps waiting something... forever...

_See the blue line_

![screenshot_20180311_084649](https://user-images.githubusercontent.com/3067335/37254171-bd7f3170-2508-11e8-8d09-e3895522bdca.png)

This change allow to send an empty list of location, so we will see an nice message saying that our implementation/definition isn't found:

![screenshot_20180311_085000](https://user-images.githubusercontent.com/3067335/37254226-2f82214c-2509-11e8-8013-01e13ed3f986.png)

This PR also simplifies our diagnostic message by removing `[crystal]` from source title:

Before:

![screenshot_20180311_085221](https://user-images.githubusercontent.com/3067335/37254251-839cac0c-2509-11e8-8068-f8637dab91bd.png)

Now:

![screenshot_20180311_085307](https://user-images.githubusercontent.com/3067335/37254261-9ed6a90a-2509-11e8-8d57-530ea60c15a4.png)
