### PR TITLE
Fixes autocompletion when constructor has integer or boolean params

### DIFF
--- a/spec/scry/completion/method_call_context_spec.cr
+++ b/spec/scry/completion/method_call_context_spec.cr
@@ -105,6 +105,29 @@ module Scry::Completion
         context = parse_example(code)
 
         context.get_type.should eq("A")
+
+        code = "
+                    a = true
+                    a = A.new(1)
+                    a‸methd
+                "
+
+        context = parse_example(code)
+
+        context.get_type.should eq("A")
+
+
+        context.get_type.should eq("A")
+
+        code = "
+                    a = true
+                    a = A.new(true)
+                    a‸methd
+                "
+
+        context = parse_example(code)
+
+        context.get_type.should eq("A")
       end
 
       context "it identifies from method defintion" do

--- a/spec/scry/completion/method_call_context_spec.cr
+++ b/spec/scry/completion/method_call_context_spec.cr
@@ -116,7 +116,6 @@ module Scry::Completion
 
         context.get_type.should eq("A")
 
-
         context.get_type.should eq("A")
 
         code = "

--- a/src/scry/completion/method_call_context.cr
+++ b/src/scry/completion/method_call_context.cr
@@ -20,9 +20,9 @@ module Scry::Completion
       elsif @text.reverse =~ Regex.union(assignment_regex, declaration_regex)
         if $~["object"]?
           case $~["object"].reverse
-          when /true|false/
+          when /\Atrue|false\z/
             "Bool"
-          when /[-+]?[0-9]+(_([iu])(8|16|32|64))?/
+          when /\A[-+]?[0-9]+(_([iu])(8|16|32|64))?\z/
             if $~[1]?
               "#{($~[2] == "i" ? "Int" : "UInt")}#{$~[3]}"
             else
@@ -38,7 +38,7 @@ module Scry::Completion
     end
 
     def assignment_regex
-      /(?<object>.*)\s*=\s*#{@target.reverse}/
+      /(?<object>\S*)\s*=\s*#{@target.reverse}/
     end
 
     def declaration_regex


### PR DESCRIPTION
Fixes the following issue.
On this scenario:
```
a = A.new(1)
a.
```

The current implementation identifies the type of a as an integer when it should be A.