### PR TITLE
Search implementations in files with implicit requires

### DIFF
--- a/spec/scry/implementations_spec.cr
+++ b/spec/scry/implementations_spec.cr
@@ -5,7 +5,8 @@ module Scry
     it "check implementation response type" do
       params = TextDocumentPositionParams.from_json(TEXTDOCUMENT_POSITION_PARAM_EXAMPLE)
       text_document = TextDocument.new(params, 0)
-      impl = Implementations.new(text_document)
+      workspace = Workspace.new("root_uri", 0, 10)
+      impl = Implementations.new(workspace, text_document)
       impl.run.is_a?(ResponseMessage).should eq(true)
     end
   end

--- a/spec/scry/response_spec.cr
+++ b/spec/scry/response_spec.cr
@@ -26,7 +26,7 @@ module Scry
       io = IO::Memory.new
       response = Response.new(results)
       response.write(io)
-      io.to_s[0...19].should eq("Content-Length: 278")
+      io.to_s[0...19].should eq("Content-Length: 268")
     end
 
     it "responds with server capabilities" do

--- a/src/scry/context.cr
+++ b/src/scry/context.cr
@@ -50,7 +50,7 @@ module Scry
       case msg.method
       when "textDocument/definition"
         text_document = TextDocument.new(params, msg.id)
-        definitions = Implementations.new(text_document)
+        definitions = Implementations.new(@workspace, text_document)
         response = definitions.run
         Log.logger.debug(response)
         response

--- a/src/scry/protocol/diagnostic.cr
+++ b/src/scry/protocol/diagnostic.cr
@@ -43,7 +43,7 @@ module Scry
         Position.new(line - 1, column + size - 1)
       )
       @severity = DiagnosticSeverity::Error.value
-      @source = "Scry [Crystal]"
+      @source = "Scry"
     end
   end
 end


### PR DESCRIPTION
**NOTE:** This feature doesn't affect scry performance, just increase the scope available to search methods and dependencies without requiring files explicitly (common practice in crystal projects)

Fixes #29

* Use root_uri from workspace
* Add get_scope to set scope to src folder on standard crystal projects
* Also get_scope sets the scope to the worspace if no src folder exists
* Send empty implementation message if an error is found...
* ...enabling the message "not found implementation" in the LSP client

The rules are:

1. If your project has a `src` directory (common on crystal projects) then you should have a main file that requires all others using `require "./**/*"` or similar
2. If your project doesn't have a `src` folder then all the workspace is analyzed in aims to search symbols and methods, excluding `spec` and `lib` directories from primary scope (methods inside `lib` dir can be found if a primary scope file requires it)

The current spec already cover part of this feature, a full spec for this is a bit complicated because it requires a full workspace to test implicit requires

This PR also include a replacement and enhancement to the fix implemented on #63

![vokoscreen-2018-04-09_02-50-12 1](https://user-images.githubusercontent.com/3067335/38490056-a080728a-3bad-11e8-815d-1fb74c72b128.gif)

