### PR TITLE
Analyze files with implicit requires

### DIFF
--- a/src/scry/analyzer.cr
+++ b/src/scry/analyzer.cr
@@ -9,13 +9,11 @@ module Scry
     end
 
     def run
-      if @text_document.inside_crystal_path?
-        clean_diagnostic
-      else
+      if !@text_document.inside_crystal_path?
         @text_document.text.map do |text|
           analyze(text)
-        end
-      end.flatten.uniq
+        end.flatten.uniq
+      end
     end
 
     # Reset all diagnostics in the current project

--- a/src/scry/publish_diagnostic.cr
+++ b/src/scry/publish_diagnostic.cr
@@ -20,18 +20,19 @@ module Scry
       notification(params)
     end
 
-    def clean
-      params = PublishDiagnosticsParams.new(@uri, [] of Diagnostic)
+    def clean(uri = @uri)
+      params = PublishDiagnosticsParams.new(uri, [] of Diagnostic)
       notification(params)
     end
 
-    def from(ex)
+    def from(ex) : Array(NotificationMessage)
       build_failures = Array(BuildFailure).from_json(ex)
       build_failures
         .uniq
         .first(@workspace.max_number_of_problems)
         .map { |bf| Diagnostic.new(bf) }
         .group_by(&.uri)
+        .select { |file, diagnostics| !file.ends_with?(".scry.cr") }
         .map { |file, diagnostics| unclean(file, diagnostics) }
     end
   end

--- a/src/scry/text_document.cr
+++ b/src/scry/text_document.cr
@@ -61,7 +61,7 @@ module Scry
     end
 
     def self.uri_to_filename(uri)
-      uri.sub(/^file:\/\/|^inmemory:\/\/|^git:\/\//, "")
+      uri.sub(/^file:\/\/|^inmemory:\/\/|^git:\/\/|^untitled:/, "")
     end
 
     def in_memory?
@@ -70,6 +70,13 @@ module Scry
 
     def untitled?
       uri.starts_with?("untitled:")
+    end
+
+    def inside_crystal_path?
+      ENV["CRYSTAL_PATH"].split(':').each do |path|
+        return true if filename.starts_with?(path)
+      end
+      false
     end
 
     def source


### PR DESCRIPTION
This PR basically adds the following feature: Analyze the code twice if undefined symbol is found on diagnostics result

The rules:

1. first time analyzes a single file and stop if no error
2. second time analyzes the entire project requiring the first level files inside src folder

**Summary of changes:**

* Add method inside_crystal_path? to avoid analizing lib and stdlib
* Send clean diagnostics for all files when a full project is analyzed
* Allow analyze files with implicit requires (main file style)
* Adds --no-debug flag for speed up compilation
* Add fake file .scry.cr to analyze a full project (aka main file)
* Remove the fake file .scry.cr from diagnostic list
* Add untitled: to the uri_to_filename method

**Use case:** very useful on those projects where you have a main file that require all other files, allowing you to write your code without multiple `require`s in every file

Fixes #29 as well

Related to #78 (This allows to remove the errors across files when you search implementations)