### PR TITLE
Makes scry settings editor agnostic

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -8,7 +8,7 @@ module Scry
 
   INITIALIZATION_EXAMPLE = %({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "processId": 1, "rootPath": "#{ROOT_PATH}", "capabilities": {} , "trace": "off"}})
 
-  CONFIG_CHANGE_EXAMPLE = %({"jsonrpc":"2.0","method":"workspace/didChangeConfiguration","params":{"settings":{"crystal-ide":{"maxNumberOfProblems":100,"backend":"scry","customCommand":"crystal","customCommandArgs":[],"logLevel":"debug"}}}})
+  CONFIG_CHANGE_EXAMPLE = %({"jsonrpc":"2.0","method":"workspace/didChangeConfiguration","params":{"settings":{"crystal":{"maxNumberOfProblems":100,"backend":"scry","customCommand":"crystal","customCommandArgs":[],"logLevel":"debug"}}}})
 
   DOC_OPEN_EXAMPLE = %({"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file://#{SOME_FILE_PATH}","languageId":"crystal","version":1,"text":"put \\"hello\\"; Thing.new"}}})
 

--- a/src/scry/protocol/did_change_configuration_params.cr
+++ b/src/scry/protocol/did_change_configuration_params.cr
@@ -3,7 +3,7 @@ require "./settings"
 module Scry
   struct DidChangeConfigurationParams
     JSON.mapping({
-      settings: SettingsCrystalIDE | SettingsCrystalLang,
+      settings: Settings,
     }, true)
   end
 end

--- a/src/scry/protocol/settings.cr
+++ b/src/scry/protocol/settings.cr
@@ -1,55 +1,19 @@
 require "json"
 
-# Add new configuration type on did_change_configuration_params.cr:6
 module Scry
-  # Configuration for vscode-crystal-ide
-  # https://github.com/kofno/crystal-ide
-  struct SettingsCrystalIDE
+  struct Settings
     JSON.mapping({
-      crystal_config: {type: CustomizationsCrystalIDE, key: "crystal-ide"},
+      crystal_config: {type: Customizations, key: /^crystal.*/, default: Customizations.from_json("{}")},
     })
   end
 
-  # :ditto:
-  struct CustomizationsCrystalIDE
+  struct Customizations
     JSON.mapping({
-      max_number_of_problems: {type: Int32, key: "maxNumberOfProblems"},
-      backend:                String,
-      custom_command:         {type: String, key: "customCommand"},
-      custom_command_args:    {type: Array(String), key: "customCommandArgs"},
-      log_level:              {type: String, key: "logLevel"},
+      max_number_of_problems: {type: Int32, key: "maxNumberOfProblems", default: 100},
+      backend:                {type: String, default: "scry"},
+      custom_command:         {type: String, key: "customCommand", default: "scry"},
+      custom_command_args:    {type: Array(String), key: "customCommandArgs", default: [] of String},
+      log_level:              {type: String, key: "logLevel", default: "info"},
     })
   end
-
-  # Configuration for vscode-crystal-lang
-  # https://github.com/faustinoaq/vscode-crystal-lang
-  struct SettingsCrystalLang
-    JSON.mapping({
-      crystal_config: {type: CustomizationsCrystalLang, key: "crystal-lang"},
-    })
-  end
-
-  # :ditto:
-  struct CustomizationsCrystalLang
-    JSON.mapping({
-      max_number_of_problems: {type: Int32, key: "maxNumberOfProblems"},
-      log_level:              {type: String, key: "logLevel"},
-    })
-  end
-
-  # Configuration for atom-crystal
-  # https://github.com/atom-crystal/scry
-  # struct SettingsAtomCrystal
-  #   JSON.mapping({
-  #     crystal_config: {type: CustomizationsAtomCrystal, key: "atom-crystal"},
-  #   })
-  # end
-
-  # :ditto:
-  # struct CustomizationsAtomCrystal
-  #   JSON.mapping({
-  #     max_number_of_problems: {type: Int32, key: "maxNumberOfProblems"},
-  #     log_level:              {type: String, key: "logLevel"},
-  #   })
-  # end
 end


### PR DESCRIPTION
* Remove vscode (crystal-ide, crystal-lang) and atom specific settings
* Read configuration from any settings starting with crystal word

Fixes #79 