### PR TITLE
Fixes InitializeParams to follow LSP specification

### DIFF
--- a/src/scry/initializer.cr
+++ b/src/scry/initializer.cr
@@ -7,7 +7,7 @@ module Scry
   struct Initializer
     def initialize(params : InitializeParams, @msg_id : Int32)
       @workspace = Workspace.new(
-        root_uri: params.root_uri,
+        root_uri: params.root_path || params.root_uri.to_s.sub("file://", ""),
         process_id: params.process_id,
         max_number_of_problems: 100
       )

--- a/src/scry/protocol/initialize_params.cr
+++ b/src/scry/protocol/initialize_params.cr
@@ -3,8 +3,9 @@ require "json"
 module Scry
   struct InitializeParams
     JSON.mapping({
-      process_id:   {type: Int64 | Int32, key: "processId"},
-      root_uri:     {type: String, key: "rootPath"},
+      process_id:   {type: Int64 | Int32 | Nil, key: "processId"},
+      root_uri:     {type: String | Nil, key: "rootUri"},
+      root_path:    {type: String | Nil, key: "rootPath", nilable: true},
       capabilities: JSON::Any,
       trace:        String?,
     })

--- a/src/scry/protocol/initialize_params.cr
+++ b/src/scry/protocol/initialize_params.cr
@@ -3,7 +3,7 @@ require "json"
 module Scry
   struct InitializeParams
     JSON.mapping({
-      process_id:   {type: Int64 | Int32 | Nil, key: "processId"},
+      process_id:   {type: Int64 | Int32 | Nil, key: "processId", nilable: true},
       root_uri:     {type: String | Nil, key: "rootUri"},
       root_path:    {type: String | Nil, key: "rootPath", nilable: true},
       capabilities: JSON::Any,

--- a/src/scry/workspace.cr
+++ b/src/scry/workspace.cr
@@ -4,7 +4,7 @@ require "./completion/method_db"
 module Scry
   struct Workspace
     property root_uri : String
-    property process_id : Int32 | Int64
+    property process_id : Int32 | Int64 | Nil
     property max_number_of_problems : Int32
     property open_files
     property dependency_graph : Completion::DependencyGraph::Graph


### PR DESCRIPTION
Fixes #72 

PR summary:

* Save compatibility with scry code base
* Adds rootUri as alternative non nilable
* Keep rootPath as default and use rootUri when this isn't available
* Makes process_id nilable