### PR TITLE
Check file inside dependency_graph before using it

### DIFF
--- a/spec/scry/completion/dependency_graph_spec.cr
+++ b/spec/scry/completion/dependency_graph_spec.cr
@@ -4,7 +4,7 @@ ROOT = File.expand_path("spec/fixtures/completion/dependency_graph")
 
 Scry::EnvironmentConfig.new
 
-CRYSTAL_PATH = ENV["CRYSTAL_PATH"]?.to_s.split(":").last? || "lib"
+CRYSTAL_PATH = Crystal::DEFAULT_PATH.split(":").last
 PRELUDE_PATH = "#{CRYSTAL_PATH}/prelude.cr"
 
 def expand(paths : Array(String))

--- a/spec/scry/completion/dependency_graph_spec.cr
+++ b/spec/scry/completion/dependency_graph_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 ROOT = File.expand_path("spec/fixtures/completion/dependency_graph")
 
-CRYSTAL_PATH = Crystal::DEFAULT_PATH.split(":").reject { |path| path == "lib" }.first
+CRYSTAL_PATH = Crystal::DEFAULT_PATH.split(":").select { |path| path.ends_with?("src") }.first
 PRELUDE_PATH = File.expand_path("prelude.cr", CRYSTAL_PATH)
 
 def expand(paths : Array(String))

--- a/spec/scry/completion/dependency_graph_spec.cr
+++ b/spec/scry/completion/dependency_graph_spec.cr
@@ -2,8 +2,6 @@ require "../../spec_helper"
 
 ROOT = File.expand_path("spec/fixtures/completion/dependency_graph")
 
-Scry::EnvironmentConfig.new
-
 CRYSTAL_PATH = Crystal::DEFAULT_PATH.split(":").last
 PRELUDE_PATH = "#{CRYSTAL_PATH}/prelude.cr"
 

--- a/spec/scry/completion/dependency_graph_spec.cr
+++ b/spec/scry/completion/dependency_graph_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 ROOT = File.expand_path("spec/fixtures/completion/dependency_graph")
 
-CRYSTAL_PATH = Crystal::DEFAULT_PATH.split(":").reject { |path| path == "lib" }.first
+CRYSTAL_PATH = Crystal::CrystalPath.default_path.split(":").first
 PRELUDE_PATH = "#{CRYSTAL_PATH}/prelude.cr"
 
 def expand(paths : Array(String))

--- a/spec/scry/completion/dependency_graph_spec.cr
+++ b/spec/scry/completion/dependency_graph_spec.cr
@@ -5,7 +5,7 @@ ROOT = File.expand_path("spec/fixtures/completion/dependency_graph")
 Scry::EnvironmentConfig.new
 
 CRYSTAL_PATH = ENV["CRYSTAL_PATH"]?.to_s.split(":").last? || "lib"
-PRELUDE_PATH = File.expand_path("prelude.cr", CRYSTAL_PATH)
+PRELUDE_PATH = "#{CRYSTAL_PATH}/prelude.cr"
 
 def expand(paths : Array(String))
   paths.map { |p| expand(p) }

--- a/spec/scry/completion/dependency_graph_spec.cr
+++ b/spec/scry/completion/dependency_graph_spec.cr
@@ -2,8 +2,8 @@ require "../../spec_helper"
 
 ROOT = File.expand_path("spec/fixtures/completion/dependency_graph")
 
-CRYSTAL_PATH = Crystal::CrystalPath.default_path.split(":").first
-PRELUDE_PATH = "#{CRYSTAL_PATH}/prelude.cr"
+CRYSTAL_PATH = Crystal::DEFAULT_PATH.split(":").reject { |path| path == "lib" }.first
+PRELUDE_PATH = File.expand_path("prelude.cr", CRYSTAL_PATH)
 
 def expand(paths : Array(String))
   paths.map { |p| expand(p) }

--- a/spec/scry/completion/dependency_graph_spec.cr
+++ b/spec/scry/completion/dependency_graph_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 ROOT = File.expand_path("spec/fixtures/completion/dependency_graph")
 
-CRYSTAL_PATH = Crystal::DEFAULT_PATH.split(":").last
+CRYSTAL_PATH = Crystal::DEFAULT_PATH.split(":").reject { |path| path == "lib" }.last
 PRELUDE_PATH = "#{CRYSTAL_PATH}/prelude.cr"
 
 def expand(paths : Array(String))

--- a/spec/scry/completion/dependency_graph_spec.cr
+++ b/spec/scry/completion/dependency_graph_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 ROOT = File.expand_path("spec/fixtures/completion/dependency_graph")
 
-CRYSTAL_PATH = Crystal::DEFAULT_PATH.split(":").reject { |path| path == "lib" }.last
+CRYSTAL_PATH = Crystal::DEFAULT_PATH.split(":").reject { |path| path == "lib" }.first
 PRELUDE_PATH = "#{CRYSTAL_PATH}/prelude.cr"
 
 def expand(paths : Array(String))

--- a/spec/scry/completion/dependency_graph_spec.cr
+++ b/spec/scry/completion/dependency_graph_spec.cr
@@ -1,9 +1,10 @@
 require "../../spec_helper"
-# require "./helper"
 
 ROOT = File.expand_path("spec/fixtures/completion/dependency_graph")
 
-CRYSTAL_PATH = Crystal::CrystalPath.default_path.split(":").last
+Scry::EnvironmentConfig.new
+
+CRYSTAL_PATH = ENV["CRYSTAL_PATH"]?.to_s.split(":").last? || "lib"
 PRELUDE_PATH = File.expand_path("prelude.cr", CRYSTAL_PATH)
 
 def expand(paths : Array(String))

--- a/spec/scry/completion/dependency_graph_spec.cr
+++ b/spec/scry/completion/dependency_graph_spec.cr
@@ -2,8 +2,7 @@ require "../../spec_helper"
 
 ROOT = File.expand_path("spec/fixtures/completion/dependency_graph")
 
-CRYSTAL_PATH = Crystal::DEFAULT_PATH.split(":").select { |path| path.ends_with?("src") }.first
-PRELUDE_PATH = File.expand_path("prelude.cr", CRYSTAL_PATH)
+PRELUDE_PATH = "#{Scry.default_crystal_path}/prelude.cr"
 
 def expand(paths : Array(String))
   paths.map { |p| expand(p) }
@@ -80,7 +79,7 @@ module Scry::Completion::DependencyGraph
       context "single file no requires with crystal path" do
         path = expand "single_file_no_requires"
         sample_1 = expand "single_file_no_requires/sample_1.cr"
-        builder = Builder.new([CRYSTAL_PATH, path])
+        builder = Builder.new(ENV["CRYSTAL_PATH"].split(":") + [path])
 
         graph = builder.build
         graph[sample_1].connections.map(&.value).should eq([PRELUDE_PATH])

--- a/spec/scry/completion/dependency_graph_spec.cr
+++ b/spec/scry/completion/dependency_graph_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 ROOT = File.expand_path("spec/fixtures/completion/dependency_graph")
 
-PRELUDE_PATH = "#{Scry.default_crystal_path}/prelude.cr"
+PRELUDE_PATH = File.expand_path("prelude.cr", Scry.default_crystal_path)
 
 def expand(paths : Array(String))
   paths.map { |p| expand(p) }

--- a/spec/scry/completion/dependency_graph_spec.cr
+++ b/spec/scry/completion/dependency_graph_spec.cr
@@ -114,8 +114,8 @@ module Scry::Completion::DependencyGraph
         graph = builder.build
 
         graph[wildcard_import_file].connections.map(&.value).sort.should eq([sample_1, sample_2, relative_import_file, PRELUDE_PATH].sort)
-        graph[sample_2].connections.map(&.value).sort.should eq([sample_1, PRELUDE_PATH])
-        graph[relative_import_file].connections.map(&.value).sort.should eq([sample_1, sample_2, PRELUDE_PATH])
+        graph[sample_2].connections.map(&.value).sort.should eq([sample_1, PRELUDE_PATH].sort)
+        graph[relative_import_file].connections.map(&.value).sort.should eq([sample_1, sample_2, PRELUDE_PATH].sort)
       end
     end
   end

--- a/spec/scry/workspace_spec.cr
+++ b/spec/scry/workspace_spec.cr
@@ -5,7 +5,7 @@ module Scry
     it ".new" do
       workspace = Workspace.new("root_uri", 0, 10)
       workspace.dependency_graph.class.should eq Scry::Completion::DependencyGraph::Graph
-      workspace.dependency_graph.each.to_a.size.should eq 0
+      workspace.dependency_graph.each.to_a.size.should eq 1
     end
 
     it ".open_workspace" do
@@ -14,7 +14,7 @@ module Scry
 
       workspace.open_workspace
 
-      workspace.dependency_graph.each.to_a.size.should_not eq 0
+      workspace.dependency_graph.each.to_a.size.should_not eq 1
     end
 
     it ".update_file" do

--- a/src/scry/completion/dependency_graph.cr
+++ b/src/scry/completion/dependency_graph.cr
@@ -28,8 +28,8 @@ module Scry::Completion::DependencyGraph
     getter prelude_node : Node
 
     def initialize(@nodes = {} of String => Node)
-      crystal_path = Crystal::DEFAULT_PATH.split(":").last
-      prelude_path = "#{crystal_path}/prelude.cr"
+      crystal_path = Crystal::DEFAULT_PATH.split(":").select { |path| path.ends_with?("src") }.first
+      prelude_path = File.expand_path("prelude.cr", CRYSTAL_PATH)
       @nodes[prelude_path] = @prelude_node = Node.new(prelude_path)
     end
 

--- a/src/scry/completion/dependency_graph.cr
+++ b/src/scry/completion/dependency_graph.cr
@@ -28,12 +28,9 @@ module Scry::Completion::DependencyGraph
     getter prelude_node : Node
 
     def initialize(@nodes = {} of String => Node)
-      if crystal_path = ENV["CRYSTAL_PATH"]?.to_s.split(":").last?
-        prelude_path = "#{crystal_path}/prelude.cr"
-        @nodes[prelude_path] = @prelude_node = Node.new(prelude_path)
-      else
-        @prelude_node = Node.new("")
-      end
+      crystal_path = Crystal::DEFAULT_PATH.split(":").last
+      prelude_path = "#{crystal_path}/prelude.cr"
+      @nodes[prelude_path] = @prelude_node = Node.new(prelude_path)
     end
 
     def [](value : String)

--- a/src/scry/completion/dependency_graph.cr
+++ b/src/scry/completion/dependency_graph.cr
@@ -1,3 +1,5 @@
+require "../default_crystal_path"
+
 module Scry::Completion::DependencyGraph
   struct Node
     property value
@@ -28,8 +30,7 @@ module Scry::Completion::DependencyGraph
     getter prelude_node : Node
 
     def initialize(@nodes = {} of String => Node)
-      crystal_path = Crystal::DEFAULT_PATH.split(":").select { |path| path.ends_with?("src") }.first
-      prelude_path = File.expand_path("prelude.cr", CRYSTAL_PATH)
+      prelude_path = "#{Scry.default_crystal_path}/prelude.cr"
       @nodes[prelude_path] = @prelude_node = Node.new(prelude_path)
     end
 

--- a/src/scry/completion/dependency_graph.cr
+++ b/src/scry/completion/dependency_graph.cr
@@ -32,6 +32,10 @@ module Scry::Completion::DependencyGraph
       @nodes[value]
     end
 
+    def []?(value : String)
+      @nodes[value]?
+    end
+
     def add_edge(value_1 : String, value_2 : String)
       add value_1
       add value_2

--- a/src/scry/completion/dependency_graph.cr
+++ b/src/scry/completion/dependency_graph.cr
@@ -30,7 +30,7 @@ module Scry::Completion::DependencyGraph
     getter prelude_node : Node
 
     def initialize(@nodes = {} of String => Node)
-      prelude_path = "#{Scry.default_crystal_path}/prelude.cr"
+      prelude_path = File.expand_path("prelude.cr", Scry.default_crystal_path)
       @nodes[prelude_path] = @prelude_node = Node.new(prelude_path)
     end
 

--- a/src/scry/completion/dependency_graph.cr
+++ b/src/scry/completion/dependency_graph.cr
@@ -78,12 +78,13 @@ module Scry::Completion::DependencyGraph
         .flat_map { |d| Dir.glob(d) }
         .each { |file| process_requires(file, graph) }
 
-      if prelude_node = graph[/src\/prelude.cr$/]
-        graph.each.reject { |e| e == prelude_node.value }.each do |key, _|
-          graph[key].connections << prelude_node
-        end
-      end
+      prelude_node = graph[/src\/prelude.cr$/]
       Log.logger.debug("Finished building the dependancy graph got these nodes:#{graph.each.to_a.map(&.first)}")
+      return graph if prelude_node.nil?
+
+      graph.each.reject { |e| e == prelude_node.not_nil!.value }.each do |key, _|
+        graph[key].connections << prelude_node.not_nil!
+      end
       graph
     end
 

--- a/src/scry/default_crystal_path.cr
+++ b/src/scry/default_crystal_path.cr
@@ -1,0 +1,10 @@
+module Scry
+  def self.default_crystal_path
+    Crystal::DEFAULT_PATH.split(":").map do |path|
+      if File.exists?("#{path}/prelude.cr")
+        return path
+      end
+    end
+    return ""
+  end
+end

--- a/src/scry/default_crystal_path.cr
+++ b/src/scry/default_crystal_path.cr
@@ -1,6 +1,6 @@
 module Scry
   def self.default_crystal_path
-    Crystal::DEFAULT_PATH.split(":").map do |path|
+    Crystal::CrystalPath.default_path.split(":").map do |path|
       if File.exists?(File.expand_path("prelude.cr", path))
         return path
       end

--- a/src/scry/default_crystal_path.cr
+++ b/src/scry/default_crystal_path.cr
@@ -1,7 +1,7 @@
 module Scry
   def self.default_crystal_path
     Crystal::DEFAULT_PATH.split(":").map do |path|
-      if File.exists?("#{path}/prelude.cr")
+      if File.exists?(File.expand_path("prelude.cr", path))
         return path
       end
     end

--- a/src/scry/workspace.cr
+++ b/src/scry/workspace.cr
@@ -25,11 +25,11 @@ module Scry
       file = TextDocument.new(params)
       if @dependency_graph[file.filename]?
         file_dependencies = @dependency_graph[file.filename].descendants.map &.value
-        method_db = Completion::MethodDB.generate(file_dependencies)
-        @open_files[file.filename] = {file, method_db}
       else
-        @open_files[file.filename] = {file, Completion::MethodDB.new}
+        file_dependencies = @dependency_graph.prelude_node.descendants.map &.value
       end
+      method_db = Completion::MethodDB.generate(file_dependencies)
+      @open_files[file.filename] = {file, method_db}
     end
 
     def update_file(params : DidChangeTextDocumentParams)
@@ -45,6 +45,7 @@ module Scry
 
     def get_file(text_document : TextDocumentIdentifier)
       filename = TextDocument.uri_to_filename(text_document.uri)
+      Log.logger.debug("@open_files: #{@open_files}")
       @open_files[filename]
     end
   end

--- a/src/scry/workspace.cr
+++ b/src/scry/workspace.cr
@@ -23,12 +23,12 @@ module Scry
 
     def put_file(params : DidOpenTextDocumentParams)
       file = TextDocument.new(params)
-      if file.untitled?
-        @open_files[file.filename] = {file, Completion::MethodDB.new}
-      else
+      if @dependency_graph[file.filename]?
         file_dependencies = @dependency_graph[file.filename].descendants.map &.value
         method_db = Completion::MethodDB.generate(file_dependencies)
         @open_files[file.filename] = {file, method_db}
+      else
+        @open_files[file.filename] = {file, Completion::MethodDB.new}
       end
     end
 


### PR DESCRIPTION
Hi scry community! :grinning: 

More fixes :tada: 

This check availability for a file inside `dependency_graph`  before call it. 

Useful for untitled files and external files

Fixes #91 
Fixes #59 

/cc @laginha87 