### PR TITLE
Add integration tests for autocomplete

### DIFF
--- a/spec/fixtures/completion/sample.cr
+++ b/spec/fixtures/completion/sample.cr
@@ -1,3 +1,4 @@
+require "./tree"
 class A
   def method
   end

--- a/spec/protocol_helper.cr
+++ b/spec/protocol_helper.cr
@@ -5,7 +5,7 @@ module Scry
     end
 
     def test_send_did_open(file_path, text)
-      test_send_notification "textDocument/didOpen", %({"textDocument":{"uri":"#{file_path}", "languageId":"crystal","version":1,"text":"#{text}" }})
+      test_send_notification "textDocument/didOpen", %({"textDocument":{"uri":"#{file_path}", "languageId":"crystal","version":1,"text":#{text.dump} }})
     end
 
     def test_send_completion(file_path, position)

--- a/spec/protocol_helper.cr
+++ b/spec/protocol_helper.cr
@@ -1,12 +1,8 @@
 module Scry
-  module ProtocolHelper
-    def self.send_init(context, root_path)
+  struct Context
+    def test_send_init( root_path)
       message = %({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "processId": 1, "rootPath": "#{root_path}", "capabilities": {} , "trace": "off"}})
-      response = context.dispatch(Message.new(message).parse)
-    end
-
-    def self.send_message(context, message)
-
+      dispatch(Message.new(message).parse)
     end
   end
 end

--- a/spec/protocol_helper.cr
+++ b/spec/protocol_helper.cr
@@ -1,0 +1,12 @@
+module Scry
+  module ProtocolHelper
+    def self.send_init(context, root_path)
+      message = %({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "processId": 1, "rootPath": "#{root_path}", "capabilities": {} , "trace": "off"}})
+      response = context.dispatch(Message.new(message).parse)
+    end
+
+    def self.send_message(context, message)
+
+    end
+  end
+end

--- a/spec/protocol_helper.cr
+++ b/spec/protocol_helper.cr
@@ -1,7 +1,26 @@
 module Scry
   struct Context
-    def test_send_init( root_path)
-      message = %({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "processId": 1, "rootPath": "#{root_path}", "capabilities": {} , "trace": "off"}})
+    def test_send_init(root_path)
+      test_send_request "initialize", %({ "processId": 1, "rootPath": "#{root_path}", "capabilities": {} , "trace": "off"})
+    end
+
+    def test_send_did_open(file_path, text)
+      test_send_notification "textDocument/didOpen", %({"textDocument":{"uri":"#{file_path}", "languageId":"crystal","version":1,"text":"#{text}" }})
+    end
+
+    def test_send_completion(file_path, position)
+      test_send_request "textDocument/completion", %({"textDocument":{"uri":"#{file_path}"},"position":#{position}})
+    end
+
+    def test_send_notification(method, params)
+      test_send  %({ "jsonrpc": "2.0", "method": "#{method}", "params": #{params}})
+    end
+
+    def test_send_request(method, params)
+      test_send %({ "jsonrpc": "2.0", "id": 1, "method": "#{method}", "params": #{params}})
+    end
+
+    def test_send(message)
       dispatch(Message.new(message).parse)
     end
   end

--- a/spec/protocol_helper.cr
+++ b/spec/protocol_helper.cr
@@ -13,7 +13,7 @@ module Scry
     end
 
     def test_send_notification(method, params)
-      test_send  %({ "jsonrpc": "2.0", "method": "#{method}", "params": #{params}})
+      test_send %({ "jsonrpc": "2.0", "method": "#{method}", "params": #{params}})
     end
 
     def test_send_request(method, params)

--- a/spec/scry/completion/method_call_context_spec.cr
+++ b/spec/scry/completion/method_call_context_spec.cr
@@ -44,7 +44,6 @@ module Scry::Completion
                     a = true
                     a‸methd
                 "
-
         context = parse_example(code)
 
         context.get_type.should eq("Bool")

--- a/spec/scry/completion_provider_spec.cr
+++ b/spec/scry/completion_provider_spec.cr
@@ -32,13 +32,13 @@ module Scry
     _context_ = Context.new
     root_path = File.expand_path("spec/fixtures/completion/")
     _context_.test_send_init(root_path)
-    _file_path_ = File.join(root_path, "tree.cr")
+    _file_path_ = File.join(root_path, "sample.cr")
 
     context "module completion" do
       _kind_ = CompletionItemKind::Module
 
       it_completes("require \"arr", ["array"])
-      it_completes("require \"./sa", ["sample"])
+      it_completes("require \"./tr", ["tree"])
     end
 
     context "method completion" do
@@ -62,6 +62,7 @@ module Scry
         it_completes("a = true
                       a.to_", %w(to_json to_s to_s to_yaml))
       end
+
       context "int32" do
         _expected_labels_ = INT32_METHODS
 
@@ -73,6 +74,59 @@ module Scry
         it_completes "a = true
                       a = 1
                       a."
+        it_completes "def blah(a : A)
+                      end
+                      def blah_2(a : Node)
+                          a = 2
+                          a."
+      end
+
+      context "tree instance methods" do
+        _expected_labels_ = %w(add print)
+
+        it_completes "abc = Node.new
+                      abc."
+
+        it_completes "abc =
+                      Node.new
+                      abc."
+        it_completes "a = true
+                      a = Node.new
+                      a."
+
+        it_completes "a = true
+                      a = Node.new(1)
+                      a."
+
+        it_completes "a = true
+                      a = Node.new(true)
+                      a."
+
+        it_completes "def blah(a : Node)
+                        a."
+
+        it_completes "def blah(a : Array)
+                      end
+                      def blah_2(a : Node)
+                          a."
+
+        it_completes "property a : Node
+                      def blah(a : A)
+                        @a."
+
+        it_completes "getter a : Node
+                      def blah(a : A)
+                        @a."
+
+        it_completes "setter a : Node
+                      def blah(a : A)
+                          @a."
+
+        it_completes "a = 2
+                      def blah_2(a : Node)
+                          a."
+
+        it_completes "Node.", %w(new)
       end
     end
   end

--- a/spec/scry/completion_provider_spec.cr
+++ b/spec/scry/completion_provider_spec.cr
@@ -2,31 +2,25 @@ require "../spec_helper"
 
 module Scry
   BOOLEAN_METHODS = %w(!= & == ^ clone hash to_json to_s to_s to_yaml |)
+  INT32_METHODS   = %w(- clone popcount)
 
-  private macro it_completes(code, with_labels, file = __FILE__, line = __LINE__)
+  private macro it_completes(code, with_labels = nil, file = __FILE__, line = __LINE__)
 
     it "completes #{{{code}}.dump}" do
+      {% if with_labels %}
+        %expected = {{with_labels}}
+      {% else %}
+        %expected = _expected_labels_
+      {% end %}
+
       %code = {{code}}
-      cursor_location = nil
-      location = %code.lines.each_with_index do |line, line_number_0|
-        if column_number = line.index('‸')
-          cursor_location = [line_number_0 + 1, column_number + 1]
-        end
+      cursor_location = [%code.lines.size, %code.size]
 
-        if column_number = line.index('༓')
-          cursor_location = [line_number_0 + 1, column_number + 1]
-        end
-      end
-
-      unless cursor_location
-        cursor_location = [0, %code.size - 1]
-      end
-      %code = %code.gsub("༓", ".").gsub("‸", "")
       _context_.test_send_did_open(_file_path_, %code)
       response = _context_.test_send_completion(_file_path_, %({"line":#{cursor_location[0]},"character":#{cursor_location[1]}}))
       results = response.as(Scry::ResponseMessage).result.as(Array(CompletionItem))
       labels = results.map(&.label)
-      labels.sort.should eq({{with_labels}}.sort)
+      labels.sort.should eq(%expected.sort)
 
       results.each do |e|
         e.kind.should eq(_kind_)
@@ -35,27 +29,51 @@ module Scry
   end
 
   describe CompletionProvider do
+    _context_ = Context.new
+    root_path = File.expand_path("spec/fixtures/completion/")
+    _context_.test_send_init(root_path)
+    _file_path_ = File.join(root_path, "tree.cr")
+
     context "module completion" do
       _kind_ = CompletionItemKind::Module
-      _context_ = Context.new
-      root_path = File.expand_path("spec/fixtures/completion/")
-      _context_.test_send_init(root_path)
-
-      _file_path_ = File.join(root_path, "tree.cr")
 
       it_completes("require \"arr", ["array"])
       it_completes("require \"./sa", ["sample"])
     end
+
     context "method completion" do
       _kind_ = CompletionItemKind::Method
-      _context_ = Context.new
-      root_path = File.expand_path("spec/fixtures/completion/")
-      _context_.test_send_init(root_path)
+      context "boolean methods" do
+        _expected_labels_ = BOOLEAN_METHODS
+        it_completes "a = true
+                      a."
 
-      _file_path_ = File.join(root_path, "tree.cr")
+        it_completes "a = false
+                      a."
 
-      it_completes("a = true
-                    a༓", BOOLEAN_METHODS)
+        it_completes "a =
+                        false
+                    a."
+
+        it_completes "a = 1
+                      a = true
+                      a."
+
+        it_completes("a = true
+                      a.to_", %w(to_json to_s to_s to_yaml))
+      end
+      context "int32" do
+        _expected_labels_ = INT32_METHODS
+
+        (1..10).each do |i|
+          it_completes "a = #{i}
+                        a."
+        end
+
+        it_completes "a = true
+                      a = 1
+                      a."
+      end
     end
   end
 end

--- a/spec/scry/completion_provider_spec.cr
+++ b/spec/scry/completion_provider_spec.cr
@@ -4,12 +4,10 @@ module Scry
   private macro it_completes(code, with_labels, file = __FILE__, line = __LINE__)
 
     it "completes #{{{code}}}" do
-      procedure = Message.new %({"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"#{__FILE_PATH__}","languageId":"crystal","version":1,"text":"#{{{code}}}"}}})
-      result = __CONTEXT__.dispatch(procedure.parse)
+      __CONTEXT__.test_send_did_open(__FILE_PATH__, {{code}})
+      response = __CONTEXT__.test_send_completion(__FILE_PATH__, %({"line":0,"character":#{{{code}}.size}}))
 
-      procedure = Message.new(%({"jsonrpc": "2.0", "id": 1, "method": "textDocument/completion", "params": {"textDocument":{"uri":"#{__FILE_PATH__}"},"position":{"line":0,"character":#{{{code}}.size}}}}))
-      response = __CONTEXT__.dispatch(procedure.parse).as(Scry::ResponseMessage)
-      results = response.result.as(Array(CompletionItem))
+      results = response.as(Scry::ResponseMessage).result.as(Array(CompletionItem))
       labels = results.map(&.label)
       labels.should eq({{with_labels}})
 

--- a/spec/scry/completion_provider_spec.cr
+++ b/spec/scry/completion_provider_spec.cr
@@ -1,33 +1,61 @@
 require "../spec_helper"
 
 module Scry
+  BOOLEAN_METHODS = %w(!= & == ^ clone hash to_json to_s to_s to_yaml |)
+
   private macro it_completes(code, with_labels, file = __FILE__, line = __LINE__)
 
-    it "completes #{{{code}}}" do
-      __CONTEXT__.test_send_did_open(__FILE_PATH__, {{code}})
-      response = __CONTEXT__.test_send_completion(__FILE_PATH__, %({"line":0,"character":#{{{code}}.size}}))
+    it "completes #{{{code}}.dump}" do
+      %code = {{code}}
+      cursor_location = nil
+      location = %code.lines.each_with_index do |line, line_number_0|
+        if column_number = line.index('‸')
+          cursor_location = [line_number_0 + 1, column_number + 1]
+        end
 
+        if column_number = line.index('༓')
+          cursor_location = [line_number_0 + 1, column_number + 1]
+        end
+      end
+
+      unless cursor_location
+        cursor_location = [0, %code.size - 1]
+      end
+      %code = %code.gsub("༓", ".").gsub("‸", "")
+      _context_.test_send_did_open(_file_path_, %code)
+      response = _context_.test_send_completion(_file_path_, %({"line":#{cursor_location[0]},"character":#{cursor_location[1]}}))
       results = response.as(Scry::ResponseMessage).result.as(Array(CompletionItem))
       labels = results.map(&.label)
-      labels.should eq({{with_labels}})
+      labels.sort.should eq({{with_labels}}.sort)
 
       results.each do |e|
-        e.kind.should eq(__KIND__)
+        e.kind.should eq(_kind_)
       end
     end
   end
 
   describe CompletionProvider do
     context "module completion" do
-      __KIND__ = CompletionItemKind::Module
-      __CONTEXT__ = Context.new
+      _kind_ = CompletionItemKind::Module
+      _context_ = Context.new
       root_path = File.expand_path("spec/fixtures/completion/")
-      __CONTEXT__.test_send_init(root_path)
+      _context_.test_send_init(root_path)
 
-      __FILE_PATH__ = File.join(root_path, "tree.cr")
+      _file_path_ = File.join(root_path, "tree.cr")
 
-      it_completes("require \\\"arr", ["array"])
-      it_completes("require \\\"./sa", ["sample"])
+      it_completes("require \"arr", ["array"])
+      it_completes("require \"./sa", ["sample"])
+    end
+    context "method completion" do
+      _kind_ = CompletionItemKind::Method
+      _context_ = Context.new
+      root_path = File.expand_path("spec/fixtures/completion/")
+      _context_.test_send_init(root_path)
+
+      _file_path_ = File.join(root_path, "tree.cr")
+
+      it_completes("a = true
+                    a༓", BOOLEAN_METHODS)
     end
   end
 end

--- a/spec/scry/completion_provider_spec.cr
+++ b/spec/scry/completion_provider_spec.cr
@@ -8,13 +8,14 @@ module Scry
       result = __CONTEXT__.dispatch(procedure.parse)
 
       procedure = Message.new(%({"jsonrpc": "2.0", "id": 1, "method": "textDocument/completion", "params": {"textDocument":{"uri":"#{__FILE_PATH__}"},"position":{"line":0,"character":#{{{code}}.size}}}}))
-      result = __CONTEXT__.dispatch(procedure.parse)
-      # labels = results.map(&.label)
-      # labels.should eq({{with_labels}})
+      response = __CONTEXT__.dispatch(procedure.parse).as(Scry::ResponseMessage)
+      results = response.result.as(Array(CompletionItem))
+      labels = results.map(&.label)
+      labels.should eq({{with_labels}})
 
-      # results.each do |e|
-      #   e.kind.should eq(__KIND__)
-      # end
+      results.each do |e|
+        e.kind.should eq(__KIND__)
+      end
     end
   end
 
@@ -23,7 +24,7 @@ module Scry
       __KIND__ = CompletionItemKind::Module
       __CONTEXT__ = Context.new
       root_path = File.expand_path("spec/fixtures/completion/")
-      ProtocolHelper.send_init(__CONTEXT__, root_path)
+      __CONTEXT__.test_send_init(root_path)
 
       __FILE_PATH__ = File.join(root_path, "tree.cr")
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "../src/scry/**"
+require "./protocol_helper"
 
 module Scry
   EnvironmentConfig.new.run

--- a/src/scry/completion_provider.cr
+++ b/src/scry/completion_provider.cr
@@ -10,7 +10,7 @@ module Scry
   end
 
   class CompletionProvider
-    METHOD_CALL_REGEX       = /(?<target>[a-zA-Z][a-zA-Z_:]*)\.(?<method>[a-zA-Z]*[a-zA-Z_:]*)$/
+    METHOD_CALL_REGEX       = /(?<target>@?[a-zA-Z][a-zA-Z_:]*)\.(?<method>[a-zA-Z]*[a-zA-Z_:]*)$/
     INSTANCE_VARIABLE_REGEX = /(?<var>@[a-zA-Z_]*)$/
     REQUIRE_MODULE_REGEX    = /require\s*\"(?<import>[a-zA-Z\/._]*)$/
 


### PR DESCRIPTION
Hi all,
when I added autcomplete I felt that the tests where too implementation specific, this PR adds specs that test the completion features as close to end to end as I could, it sends a jsonrpc message and a parses the json response to check the results. Also wanted an excuse to play around with macros :D. 
This way we're not really tied to the implementation we have, actually ended up fixing an issue when completing propertys, getters and setters. 