### PR TITLE
Add symbol end_position using end_location

### DIFF
--- a/src/scry/symbol.cr
+++ b/src/scry/symbol.cr
@@ -87,20 +87,24 @@ module Scry
 
     def process_node(node, name : String, kind : SymbolKind)
       location = node.location
-      end_location = node.end_location
-      return true unless location && end_location
+      return true unless location
 
       line_number = location.line_number
       column_number = location.column_number
-      end_line_number = end_location.line_number
-      end_column_number = end_location.column_number
       position = Position.new(line_number - 1, column_number - 1)
+      end_location = node.end_location
+      if end_location
+        end_line_number = end_location.line_number
+        end_column_number = end_location.column_number
+      else
+        end_line_number = line_number
+        end_column_number = column_number
+      end
       end_position = Position.new(end_line_number - 1, end_column_number - 1)
+
       range = Range.new(position, end_position)
       location = Location.new(@document_uri, range)
-
       @symbols << SymbolInformation.new(name, kind, location, @container.join("::"))
-
       true
     end
   end

--- a/src/scry/symbol.cr
+++ b/src/scry/symbol.cr
@@ -87,7 +87,7 @@ module Scry
 
     def process_node(node, name : String, kind : SymbolKind)
       location = node.location
-      return true unless location
+      return unless location
 
       line_number = location.line_number
       column_number = location.column_number
@@ -105,7 +105,6 @@ module Scry
       range = Range.new(position, end_position)
       location = Location.new(@document_uri, range)
       @symbols << SymbolInformation.new(name, kind, location, @container.join("::"))
-      true
     end
   end
 

--- a/src/scry/symbol.cr
+++ b/src/scry/symbol.cr
@@ -87,13 +87,16 @@ module Scry
 
     def process_node(node, name : String, kind : SymbolKind)
       location = node.location
-      return true unless location
+      end_location = node.end_location
+      return true unless location && end_location
 
       line_number = location.line_number
       column_number = location.column_number
-
+      end_line_number = end_location.line_number
+      end_column_number = end_location.column_number
       position = Position.new(line_number - 1, column_number - 1)
-      range = Range.new(position, position)
+      end_position = Position.new(end_line_number - 1, end_column_number - 1)
+      range = Range.new(position, end_position)
       location = Location.new(@document_uri, range)
 
       @symbols << SymbolInformation.new(name, kind, location, @container.join("::"))

--- a/src/scry/symbol.cr
+++ b/src/scry/symbol.cr
@@ -92,8 +92,8 @@ module Scry
       line_number = location.line_number
       column_number = location.column_number
       position = Position.new(line_number - 1, column_number - 1)
-      end_location = node.end_location
-      if end_location
+
+      if end_location = node.end_location
         end_line_number = end_location.line_number
         end_column_number = end_location.column_number
       else


### PR DESCRIPTION
I just found this enhancement during development of rename feature

This will allow us to show code outline properly :tada: 

![screenshot_20180506_163009](https://user-images.githubusercontent.com/3067335/39678039-bf5706d0-514a-11e8-8add-563cdf9efcaa.png)
