### PR TITLE
Use shards build

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To install scry download it from [releases page](https://github.com/crystal-lang
 ```
 git clone https://github.com/crystal-lang-tools/scry.git
 cd scry
-crystal build --status --progress --no-debug src/scry.cr
+shards build -v
 ```
 
 Then setup `scry` binary path on your LSP client.


### PR DESCRIPTION
This PR change `crystal build` by `shards build` on README, so we can recommend to use our available target on `shard.yml`

```yml
targets:
  scry:
    main: src/scry.cr
```