### PR TITLE
Only analyze twice if main file exists

### DIFF
--- a/src/scry/analyzer.cr
+++ b/src/scry/analyzer.cr
@@ -28,14 +28,10 @@ module Scry
       else
         # Crystal compiler needs a main file to compile
         # By default it uses .scry_main.cr on workspace root,
-        # if src dir exists and the error is caused by un undefined symbol,
-        # then it requires ./src/* files
-        # Otherwise You can create your own .scry_main.cr
+        # otherwise return the current diagnostic.
         main_file = File.join(root_uri, ".scry_main.cr")
         main_code = if File.exists?(main_file)
                       File.read(main_file)
-                    elsif Dir.exists?(File.join(root_uri, "src")) && response.includes?("undefined")
-                      %(require "./src/*")
                     else
                       return @diagnostic.from(response)
                     end


### PR DESCRIPTION
Hi @crystal-lang-tools/scry team!

I have been working on several crystal projects latest weeks and I realize sometimes scry is very slow because is launching too much heavy crystal processes in background.

This change removes the implicit requires by removing `require "./src/*"` from analyzer, you still can use this behaivior by adding the explicit require inside your `.scry_main.cr` file.

BTW, I already have some progress in `.scry.yml` configuration, so you will be able to edit the main file very soon :wink: 