### PR TITLE
Log response on exception

### DIFF
--- a/src/scry/analyzer.cr
+++ b/src/scry/analyzer.cr
@@ -47,7 +47,7 @@ module Scry
         end
       end
     rescue ex
-      Log.logger.error("A error was found while searching diagnostics\n#{ex}")
+      Log.logger.error("A error was found while searching diagnostics\n#{ex}\n#{response}")
       nil
     end
 

--- a/src/scry/formatter.cr
+++ b/src/scry/formatter.cr
@@ -29,7 +29,7 @@ module Scry
         ResponseMessage.new(@text_document.id, [TextEdit.new(range, result)])
       end
     rescue ex
-      Log.logger.error("A error was found while formatting\n#{ex}")
+      Log.logger.error("A error was found while formatting\n#{ex}\n#{result}")
       nil
     end
   end

--- a/src/scry/hover_provider.cr
+++ b/src/scry/hover_provider.cr
@@ -40,8 +40,8 @@ module Scry
     end
 
     private def analyze(filename, position, scope)
-      response = crystal_tool(filename, position, scope)
-      response = (Array(BuildFailure) | HoverResponse).from_json(response)
+      result = crystal_tool(filename, position, scope)
+      response = (Array(BuildFailure) | HoverResponse).from_json(result)
       case response
       when Array(BuildFailure)
         hover_response
@@ -53,7 +53,7 @@ module Scry
         end
       end
     rescue ex
-      Log.logger.error("A error was found while searching contexts\n#{ex}")
+      Log.logger.error("A error was found while searching contexts\n#{ex}\n#{result}")
       hover_response
     end
 

--- a/src/scry/implementations.cr
+++ b/src/scry/implementations.cr
@@ -48,9 +48,9 @@ module Scry
     end
 
     private def analyze(filename, position, scope)
-      response = crystal_tool(filename, position, scope)
-      Log.logger.debug("response: #{response}")
-      response = (Array(BuildFailure) | ImplementationsResponse).from_json(response)
+      result = crystal_tool(filename, position, scope)
+      Log.logger.debug("result: #{result}")
+      response = (Array(BuildFailure) | ImplementationsResponse).from_json(result)
       case response
       when Array(BuildFailure)
         implementation_response
@@ -62,7 +62,7 @@ module Scry
         end
       end
     rescue ex
-      Log.logger.error("A error was found while searching implementations\n#{ex}")
+      Log.logger.error("A error was found while searching implementations\n#{ex}\n#{result}")
       implementation_response
     end
 


### PR DESCRIPTION
Hi @crystal-lang-tools/scry team!

This PR add more information when an exception is triggered, so is easy to debug crystal bugs because exception itself doesn't give relevant info, just an JSON parse error, possible change here: https://github.com/crystal-lang/crystal/pull/5932 (But still not enough info)
