### PR TITLE
Remove query_regex on workspace symbol search

### DIFF
--- a/spec/scry/symbol_spec.cr
+++ b/spec/scry/symbol_spec.cr
@@ -114,13 +114,6 @@ module Scry
         result.kind.is_a?(SymbolKind::Method).should be_true
       end
 
-      it "return stdlib Symbol with query match for File" do
-        processor = WorkspaceSymbolProcessor.new(0, ROOT_PATH, "File")
-        response = processor.run
-        result = response.result.as(Array(SymbolInformation)).first
-        result.kind.is_a?(SymbolKind::Class).should be_true
-      end
-
       it "return stdlib symbol with query match for initialize" do
         processor = WorkspaceSymbolProcessor.new(0, ROOT_PATH, "initialize")
         response = processor.run

--- a/spec/scry/symbol_spec.cr
+++ b/spec/scry/symbol_spec.cr
@@ -107,7 +107,7 @@ module Scry
         result.empty?.should be_true
       end
 
-      it "return Symbols list with query match for saludo (example file)" do
+      it "return Symbols list with query match for saluto (example file)" do
         processor = WorkspaceSymbolProcessor.new(0, ROOT_PATH, "saluto")
         response = processor.run
         result = response.result.as(Array(SymbolInformation)).first

--- a/spec/scry/symbol_spec.cr
+++ b/spec/scry/symbol_spec.cr
@@ -107,29 +107,22 @@ module Scry
         result.empty?.should be_true
       end
 
-      it "return Symbols list with query match" do
-        processor = WorkspaceSymbolProcessor.new(0, ROOT_PATH, "salut")
+      it "return Symbols list with query match for saludo (example file)" do
+        processor = WorkspaceSymbolProcessor.new(0, ROOT_PATH, "saluto")
         response = processor.run
         result = response.result.as(Array(SymbolInformation)).first
         result.kind.is_a?(SymbolKind::Method).should be_true
       end
 
-      it "return Symbols list with regex query match" do
-        processor = WorkspaceSymbolProcessor.new(0, ROOT_PATH, "sal*")
-        response = processor.run
-        result = response.result.as(Array(SymbolInformation)).first
-        result.kind.is_a?(SymbolKind::Method).should be_true
-      end
-
-      it "return stdlib Symbol with regex query match for File" do
-        processor = WorkspaceSymbolProcessor.new(0, ROOT_PATH, "Fil*")
+      it "return stdlib Symbol with query match for File" do
+        processor = WorkspaceSymbolProcessor.new(0, ROOT_PATH, "File")
         response = processor.run
         result = response.result.as(Array(SymbolInformation)).first
         result.kind.is_a?(SymbolKind::Class).should be_true
       end
 
-      it "return stdlib symbol with regex query match for initialize" do
-        processor = WorkspaceSymbolProcessor.new(0, ROOT_PATH, "initializ*")
+      it "return stdlib symbol with query match for initialize" do
+        processor = WorkspaceSymbolProcessor.new(0, ROOT_PATH, "initialize")
         response = processor.run
         result = response.result.as(Array(SymbolInformation)).first
         result.kind.is_a?(SymbolKind::Method).should be_true


### PR DESCRIPTION
Hi @crystal-lang-tools/scry team!

This PR removes `query_regex` because using regex can be ultra slow, also can produce unexpected behaviors :sweat_smile: 