### PR TITLE
Clean file diagnostics on close

### DIFF
--- a/src/scry/context.cr
+++ b/src/scry/context.cr
@@ -143,6 +143,7 @@ module Scry
       case msg.method
       when "textDocument/didClose"
         @workspace.drop_file(params)
+        return PublishDiagnostic.new(@workspace, params.text_document.uri).full_clean
       end
       nil
     end

--- a/src/scry/context.cr
+++ b/src/scry/context.cr
@@ -180,7 +180,8 @@ module Scry
     end
 
     private def dispatch_notification(params : DidChangeWatchedFilesParams, msg)
-      file_event = params.changes.first?
+      return if params.changes.empty?
+      file_event = params.changes.first
       handle_file_event(file_event)
     end
 

--- a/src/scry/context.cr
+++ b/src/scry/context.cr
@@ -180,9 +180,8 @@ module Scry
     end
 
     private def dispatch_notification(params : DidChangeWatchedFilesParams, msg)
-      params.changes.map { |file_event|
-        handle_file_event(file_event)
-      }.compact
+      file_event = params.changes.first?
+      handle_file_event(file_event)
     end
 
     private def handle_file_event(file_event : FileEvent)

--- a/src/scry/publish_diagnostic.cr
+++ b/src/scry/publish_diagnostic.cr
@@ -33,7 +33,7 @@ module Scry
       clean_diagnostics = ALL_FILES_WITH_DIAGNOSTIC[@uri].map do |file|
         clean(file)
       end
-      ALL_FILES_WITH_DIAGNOSTIC[@uri].clear
+      ALL_FILES_WITH_DIAGNOSTIC.delete(@uri)
       clean_diagnostics << clean if clean_diagnostics.empty?
       clean_diagnostics
     end

--- a/src/scry/publish_diagnostic.cr
+++ b/src/scry/publish_diagnostic.cr
@@ -29,6 +29,7 @@ module Scry
     # If the computed set is empty it has to push the empty array to clear former diagnostic
     # See: https://microsoft.github.io/language-server-protocol/specification#textDocument_publishDiagnostics
     def full_clean
+      Log.logger.debug(ALL_FILES_WITH_DIAGNOSTIC)
       clean_diagnostics = ALL_FILES_WITH_DIAGNOSTIC[@uri].map do |file|
         clean(file)
       end

--- a/src/scry/publish_diagnostic.cr
+++ b/src/scry/publish_diagnostic.cr
@@ -13,7 +13,7 @@ module Scry
     ALL_FILES_WITH_DIAGNOSTIC = {} of String => Array(String)
 
     def initialize(@workspace : Workspace, @uri : String)
-      ALL_FILES_WITH_DIAGNOSTIC[@uri] = [] of String
+      ALL_FILES_WITH_DIAGNOSTIC[@uri] ||= [] of String
     end
 
     private def notification(params)
@@ -29,7 +29,6 @@ module Scry
     # If the computed set is empty it has to push the empty array to clear former diagnostic
     # See: https://microsoft.github.io/language-server-protocol/specification#textDocument_publishDiagnostics
     def full_clean
-      Log.logger.debug(ALL_FILES_WITH_DIAGNOSTIC)
       clean_diagnostics = ALL_FILES_WITH_DIAGNOSTIC[@uri].map do |file|
         clean(file)
       end


### PR DESCRIPTION
Hi @crystal-lang-tools/scry team!

This PR add `.full_clean` method to clean file diagnostics when a file is closed, this can allow us to remove unwanted diagnostics from editor. Current behavior keeps diagnostics even if they are already fixed because we need to open it again and configure `.scry_main`. This approach is already used when a file is deleted.

 