### PR TITLE
Reduce some code duplication for WS symbols

### DIFF
--- a/spec/scry/symbol_spec.cr
+++ b/spec/scry/symbol_spec.cr
@@ -2,56 +2,50 @@ require "../spec_helper"
 
 module Scry
   describe SymbolProcessor do
-    it "returns a ResponseMessage" do
-      text_document = TextDocument.new("inmemory://model/3", [""])
-      processor = SymbolProcessor.new(text_document)
-      processor.run.is_a?(ResponseMessage).should be_true
-    end
-
     it "contains SymbolInformation" do
       text_document = TextDocument.new("uri", [""])
       processor = SymbolProcessor.new(text_document)
       response = processor.run
-      response.result.is_a?(Array(SymbolInformation)).should be_true
+      response.is_a?(Array(SymbolInformation)).should be_true
     end
 
     it "returns Class symbols" do
       text_document = TextDocument.new("uri", ["class Test; end"])
       processor = SymbolProcessor.new(text_document)
-      response = processor.run
-      result = response.result.as(Array(SymbolInformation)).first
+      symbols = processor.run
+      result = symbols.first
       result.kind.is_a?(SymbolKind::Class).should be_true
     end
 
     it "returns Struct symbols as a Class" do
       text_document = TextDocument.new("uri", ["struct Test; end"])
       processor = SymbolProcessor.new(text_document)
-      response = processor.run
-      result = response.result.as(Array(SymbolInformation)).first
+      symbols = processor.run
+      result = symbols.first
       result.kind.is_a?(SymbolKind::Class).should be_true
     end
 
     it "returns Module symbols" do
       text_document = TextDocument.new("uri", ["module Test; end"])
       processor = SymbolProcessor.new(text_document)
-      response = processor.run
-      result = response.result.as(Array(SymbolInformation)).first
+      symbols = processor.run
+      result = symbols.first
       result.kind.is_a?(SymbolKind::Module).should be_true
     end
 
     it "returns Method symbols" do
       text_document = TextDocument.new("uri", ["def test; end"])
       processor = SymbolProcessor.new(text_document)
-      response = processor.run
-      result = response.result.as(Array(SymbolInformation)).first
+      symbols = processor.run
+      result = symbols.first
       result.kind.is_a?(SymbolKind::Method).should be_true
     end
 
     it "returns instance vars as Variable symbols" do
       text_document = TextDocument.new("uri", ["@bar = nil"])
       processor = SymbolProcessor.new(text_document)
-      response = processor.run
-      result = response.result.as(Array(SymbolInformation)).first
+      symbols = processor.run
+      result = symbols.first
       result.as(SymbolInformation).kind.is_a?(SymbolKind::Variable).should be_true
     end
 
@@ -59,24 +53,24 @@ module Scry
       it "returns getters as Property symbols" do
         text_document = TextDocument.new("uri", ["class Foo; getter bar : Nil; end"])
         processor = SymbolProcessor.new(text_document)
-        response = processor.run
-        result = response.result.as(Array(SymbolInformation)).try { |r| r[1] }
+        symbols = processor.run
+        result = symbols.as(Array(SymbolInformation)).try { |r| r[1] }
         result.as(SymbolInformation).kind.is_a?(SymbolKind::Property).should be_true
       end
 
       it "returns setters as Property symbols" do
         text_document = TextDocument.new("uri", ["class Foo; setter bar : Nil; end"])
         processor = SymbolProcessor.new(text_document)
-        response = processor.run
-        result = response.result.as(Array(SymbolInformation)).try { |r| r[1] }
+        symbols = processor.run
+        result = symbols.as(Array(SymbolInformation)).try { |r| r[1] }
         result.as(SymbolInformation).kind.is_a?(SymbolKind::Property).should be_true
       end
 
       it "returns properties as Property symbols" do
         text_document = TextDocument.new("uri", ["class Foo; property bar : Nil; end"])
         processor = SymbolProcessor.new(text_document)
-        response = processor.run
-        result = response.result.as(Array(SymbolInformation)).try { |r| r[1] }
+        symbols = processor.run
+        result = symbols.as(Array(SymbolInformation)).try { |r| r[1] }
         result.as(SymbolInformation).kind.is_a?(SymbolKind::Property).should be_true
       end
     end
@@ -85,39 +79,38 @@ module Scry
       it "returns Constant symbols" do
         text_document = TextDocument.new("uri", [%(HELLO = "world")])
         processor = SymbolProcessor.new(text_document)
-        response = processor.run
-        result = response.result.as(Array(SymbolInformation)).first
+        symbols = processor.run
+        result = symbols.first
         result.kind.is_a?(SymbolKind::Constant).should be_true
       end
 
       it "returns alias as Constant symbols" do
         text_document = TextDocument.new("uri", [%(alias Hello = World)])
         processor = SymbolProcessor.new(text_document)
-        response = processor.run
-        result = response.result.as(Array(SymbolInformation)).first
+        symbols = processor.run
+        result = symbols.first
         result.kind.is_a?(SymbolKind::Constant).should be_true
       end
     end
 
     describe "WorkspaceSymbols" do
       it "return empty Symbols list if no query" do
-        processor = WorkspaceSymbolProcessor.new(0, ROOT_PATH, "")
-        response = processor.run
-        result = response.result.as(Array(SymbolInformation))
-        result.empty?.should be_true
+        processor = WorkspaceSymbolProcessor.new(ROOT_PATH, "")
+        symbols = processor.run
+        symbols.empty?.should be_true
       end
 
       it "return Symbols list with query match for saluto (example file)" do
-        processor = WorkspaceSymbolProcessor.new(0, ROOT_PATH, "saluto")
-        response = processor.run
-        result = response.result.as(Array(SymbolInformation)).first
+        processor = WorkspaceSymbolProcessor.new(ROOT_PATH, "saluto")
+        symbols = processor.run
+        result = symbols.first
         result.kind.is_a?(SymbolKind::Method).should be_true
       end
 
       it "return stdlib symbol with query match for initialize" do
-        processor = WorkspaceSymbolProcessor.new(0, ROOT_PATH, "initialize")
-        response = processor.run
-        result = response.result.as(Array(SymbolInformation)).first
+        processor = WorkspaceSymbolProcessor.new(ROOT_PATH, "initialize")
+        symbols = processor.run
+        result = symbols.first
         result.kind.is_a?(SymbolKind::Method).should be_true
       end
     end

--- a/src/scry/context.cr
+++ b/src/scry/context.cr
@@ -101,7 +101,8 @@ module Scry
       when "textDocument/documentSymbol"
         text_document = TextDocument.new(params, msg.id)
         symbol_processor = SymbolProcessor.new(text_document)
-        response = symbol_processor.run
+        symbols = symbol_processor.run
+        response = ResponseMessage.new(msg.id, symbols)
         Log.logger.debug(response)
         response
       end
@@ -110,10 +111,9 @@ module Scry
     private def dispatch_request(params : WorkspaceSymbolParams, msg)
       case msg.method
       when "workspace/symbol"
-        query = params.query
-        root_path = TextDocument.uri_to_filename(@workspace.root_uri)
-        workspace_symbol_processor = WorkspaceSymbolProcessor.new(msg.id, root_path, query)
-        response = workspace_symbol_processor.run
+        workspace_symbol_processor = WorkspaceSymbolProcessor.new(@workspace.root_uri, params.query)
+        symbols = workspace_symbol_processor.run
+        response = ResponseMessage.new(msg.id, symbols)
         Log.logger.debug(response)
         response
       end

--- a/src/scry/text_document.cr
+++ b/src/scry/text_document.cr
@@ -17,6 +17,11 @@ module Scry
       @filename = uri_to_filename
     end
 
+    def initialize(@uri)
+      @filename = uri_to_filename
+      @text = [read_file]
+    end
+
     def initialize(params : DidOpenTextDocumentParams)
       @uri = params.text_document.uri
       @filename = uri_to_filename


### PR DESCRIPTION
Attempted to cleanup some of the code duplication when determining Workspace symbols.  In the process I also removed the coupling of the `SymbolProcessors` and the actual `ResponseMessage`.  I think doing this will allow us to reuse some of this for additional Symbol features more easily.