### PR TITLE
Protocol namespace

### DIFF
--- a/spec/scry/client_spec.cr
+++ b/spec/scry/client_spec.cr
@@ -5,13 +5,13 @@ module Scry
     describe "#send_message" do
       it "sends a valid NotificationMessage to the Client io" do
         build_failure = BuildFailure.from_json(BUILD_ERROR_EXAMPLE)
-        diagnostic = Diagnostic.new(build_failure)
+        diagnostic = Protocol::Diagnostic.new(build_failure)
 
-        params = PublishDiagnosticsParams.new(
+        params = Protocol::PublishDiagnosticsParams.new(
           "file:///Users/foo/project/some_file.cr",
           [diagnostic]
         )
-        message = NotificationMessage.new("textDocument/publishDiagnostics", params)
+        message = Protocol::NotificationMessage.new("textDocument/publishDiagnostics", params)
 
         io = IO::Memory.new
         client = Client.new(io)
@@ -20,7 +20,7 @@ module Scry
       end
 
       it "sends a valid Initialize Reponse to the Client io" do
-        message = Initialize.new(32)
+        message = Protocol::Initialize.new(32)
 
         io = IO::Memory.new
         client = Client.new(io)
@@ -29,8 +29,8 @@ module Scry
       end
 
       it "sends a valid ResponseMessage to the Client io" do
-        result = [] of SymbolInformation
-        message = ResponseMessage.new(1, result)
+        result = [] of Protocol::SymbolInformation
+        message = Protocol::ResponseMessage.new(1, result)
 
         io = IO::Memory.new
         client = Client.new(io)
@@ -40,8 +40,8 @@ module Scry
 
       it "sends multiple ClientMessages" do
         messages = [] of Client::ClientMessage
-        messages << NotificationMessage.new("fake1", VoidParams.from_json("{}"))
-        messages << NotificationMessage.new("fake2", VoidParams.from_json("{}"))
+        messages << Protocol::NotificationMessage.new("fake1", Protocol::VoidParams.from_json("{}"))
+        messages << Protocol::NotificationMessage.new("fake2", Protocol::VoidParams.from_json("{}"))
 
         io = IO::Memory.new
         client = Client.new(io)

--- a/spec/scry/completion_provider_spec.cr
+++ b/spec/scry/completion_provider_spec.cr
@@ -18,7 +18,7 @@ module Scry
 
       _context_.test_send_did_open(_file_path_, %code)
       response = _context_.test_send_completion(_file_path_, %({"line":#{cursor_location[0]},"character":#{cursor_location[1]}}))
-      results = response.as(Scry::ResponseMessage).result.as(Array(CompletionItem))
+      results = response.as(Protocol::ResponseMessage).result.as(Array(Protocol::CompletionItem))
       labels = results.map(&.label)
       labels.sort.should eq(%expected.sort)
 
@@ -35,14 +35,14 @@ module Scry
     _file_path_ = File.join(root_path, "sample.cr")
 
     context "module completion" do
-      _kind_ = CompletionItemKind::Module
+      _kind_ = Protocol::CompletionItemKind::Module
 
       it_completes("require \"arr", ["array"])
       it_completes("require \"./tr", ["tree"])
     end
 
     context "method completion" do
-      _kind_ = CompletionItemKind::Method
+      _kind_ = Protocol::CompletionItemKind::Method
       context "boolean methods" do
         _expected_labels_ = BOOLEAN_METHODS
         it_completes "a = true
@@ -134,7 +134,7 @@ module Scry
     end
 
     context "module, struct and class name completion" do
-      _kind_ = CompletionItemKind::Class
+      _kind_ = Protocol::CompletionItemKind::Class
       it_completes("A", %w(Array Atomic ArgumentError AtExitHandlers))
       it_completes(" ::A", %w(Array Atomic ArgumentError AtExitHandlers))
       it_completes(" ::", %w())

--- a/spec/scry/completion_resolver_spec.cr
+++ b/spec/scry/completion_resolver_spec.cr
@@ -4,23 +4,23 @@ module Scry
   describe CompletionResolver do
     it "handles require module completions" do
       tree_path = File.expand_path("spec/fixtures/completion/tree.cr")
-      context = RequireModuleContextData.new(tree_path)
-      completion_item = CompletionItem.new(label = "mock", kind = CompletionItemKind::Text, detail = "mock detail", data = context, documentation = nil)
+      context = Protocol::RequireModuleContextData.new(tree_path)
+      completion_item = Protocol::CompletionItem.new(label = "mock", kind = Protocol::CompletionItemKind::Text, detail = "mock detail", data = context, documentation = nil)
       completion_resolver = CompletionResolver.new(1, completion_item)
 
-      results = completion_resolver.run.as(CompletionItem)
-      doc = results.documentation.as(MarkupContent)
+      results = completion_resolver.run.as(Protocol::CompletionItem)
+      doc = results.documentation.as(Protocol::MarkupContent)
       doc.value.should eq("```crystal\n# taken from https://raw.githubusercontent.com/crystal-lang/crystal/master/samples/tree.cr\nclass Node\n  @left : self?\n  @right : self?\n\n```")
     end
 
     it "handles method completions" do
       tree_path = File.expand_path("spec/fixtures/completion/tree.cr")
-      context = MethodCallContextData.new(tree_path, ":10:3")
-      completion_item = CompletionItem.new(label = "mock", kind = CompletionItemKind::Text, detail = "mock detail", data = context, documentation = nil)
+      context = Protocol::MethodCallContextData.new(tree_path, ":10:3")
+      completion_item = Protocol::CompletionItem.new(label = "mock", kind = Protocol::CompletionItemKind::Text, detail = "mock detail", data = context, documentation = nil)
       completion_resolver = CompletionResolver.new(1, completion_item)
 
-      results = completion_resolver.run.as(CompletionItem)
-      doc = results.documentation.as(MarkupContent)
+      results = completion_resolver.run.as(Protocol::CompletionItem)
+      doc = results.documentation.as(Protocol::MarkupContent)
       doc.value.should eq(" Adds a node to the tree")
     end
   end

--- a/spec/scry/context_spec.cr
+++ b/spec/scry/context_spec.cr
@@ -7,7 +7,7 @@ module Scry
 
       procedure = Message.new(INITIALIZATION_EXAMPLE).parse
       result = context.dispatch(procedure)
-      result.is_a?(Initialize).should be_true
+      result.is_a?(Protocol::Initialize).should be_true
 
       procedure = Message.new(CONFIG_CHANGE_EXAMPLE).parse
       context.dispatch(procedure)

--- a/spec/scry/formatter_spec.cr
+++ b/spec/scry/formatter_spec.cr
@@ -6,7 +6,7 @@ module Scry
       workspace = Workspace.new("root_uri", 0, 10)
       text_document = TextDocument.new("uri", ["1+1"])
       format = Formatter.new(workspace, text_document)
-      format.run.is_a?(ResponseMessage).should eq(true)
+      format.run.is_a?(Protocol::ResponseMessage).should eq(true)
     end
 
     it "check formatter response content" do
@@ -19,7 +19,7 @@ module Scry
 
     it "check formatter on untitled file" do
       workspace = Workspace.new("root_uri", 0, 10)
-      workspace.put_file(DidOpenTextDocumentParams.from_json(UNTITLED_FORMATTER_EXAMPLE))
+      workspace.put_file(Protocol::DidOpenTextDocumentParams.from_json(UNTITLED_FORMATTER_EXAMPLE))
       text_document, empty_completion = workspace.open_files["untitled:Untitled-1"]
       format = Formatter.new(workspace, text_document)
       response = format.run

--- a/spec/scry/hover_spec.cr
+++ b/spec/scry/hover_spec.cr
@@ -3,11 +3,11 @@ require "../spec_helper"
 module Scry
   describe HoverProvider do
     it "check hover response type" do
-      params = TextDocumentPositionParams.from_json(TEXTDOCUMENT_POSITION_PARAM_EXAMPLE)
+      params = Protocol::TextDocumentPositionParams.from_json(TEXTDOCUMENT_POSITION_PARAM_EXAMPLE)
       text_document = TextDocument.new(params, 0)
       workspace = Workspace.new("root_uri", 0, 10)
       impl = HoverProvider.new(workspace, text_document)
-      impl.run.is_a?(ResponseMessage).should eq(true)
+      impl.run.is_a?(Protocol::ResponseMessage).should eq(true)
     end
   end
 end

--- a/spec/scry/implementations_spec.cr
+++ b/spec/scry/implementations_spec.cr
@@ -3,11 +3,11 @@ require "../spec_helper"
 module Scry
   describe Implementations do
     it "check implementation response type" do
-      params = TextDocumentPositionParams.from_json(TEXTDOCUMENT_POSITION_PARAM_EXAMPLE)
+      params = Protocol::TextDocumentPositionParams.from_json(TEXTDOCUMENT_POSITION_PARAM_EXAMPLE)
       text_document = TextDocument.new(params, 0)
       workspace = Workspace.new("root_uri", 0, 10)
       impl = Implementations.new(workspace, text_document)
-      impl.run.is_a?(ResponseMessage).should eq(true)
+      impl.run.is_a?(Protocol::ResponseMessage).should eq(true)
     end
   end
 end

--- a/spec/scry/initialize_spec.cr
+++ b/spec/scry/initialize_spec.cr
@@ -4,7 +4,7 @@ module Scry
   describe Initializer do
     it "build a new workspace" do
       initer = Initializer.new(
-        InitializeParams.from_json({
+        Protocol::InitializeParams.from_json({
           processId:    1,
           rootPath:     "/home/main/Projects/Experiment",
           capabilities: {} of String => String,

--- a/spec/scry/message_spec.cr
+++ b/spec/scry/message_spec.cr
@@ -4,37 +4,37 @@ module Scry
   describe Message do
     it "creates an initialization request" do
       procedure = Message.new(INITIALIZATION_EXAMPLE).parse
-      procedure.is_a?(RequestMessage).should be_true
+      procedure.is_a?(Protocol::RequestMessage).should be_true
     end
 
     it "creates configuration change request" do
       procedure = Message.new(CONFIG_CHANGE_EXAMPLE).parse
-      procedure.is_a?(NotificationMessage).should be_true
+      procedure.is_a?(Protocol::NotificationMessage).should be_true
     end
 
     it "creates a document opened request" do
       procedure = Message.new(DOC_OPEN_EXAMPLE).parse
-      procedure.is_a?(NotificationMessage).should be_true
+      procedure.is_a?(Protocol::NotificationMessage).should be_true
     end
 
     it "handles no-argument procedure calls" do
       procedure = Message.new(SHUTDOWN_EXAMPLE).parse
-      procedure.is_a?(RequestMessage).should be_true
+      procedure.is_a?(Protocol::RequestMessage).should be_true
     end
 
     it "creates a didSave notification" do
       procedure = Message.new(DID_SAVE_EXAMPLE).parse
-      procedure.is_a?(NotificationMessage).should be_true
+      procedure.is_a?(Protocol::NotificationMessage).should be_true
     end
 
     it "creates a didClose notification" do
       procedure = Message.new(DOC_CLOSE_EXAMPLE).parse
-      procedure.is_a?(NotificationMessage).should be_true
+      procedure.is_a?(Protocol::NotificationMessage).should be_true
     end
 
     it "creates a initialized notification" do
       procedure = Message.new(INITIALIZED_EXAMPLE).parse
-      procedure.is_a?(NotificationMessage).should be_true
+      procedure.is_a?(Protocol::NotificationMessage).should be_true
     end
   end
 end

--- a/spec/scry/parse_analyzer_spec.cr
+++ b/spec/scry/parse_analyzer_spec.cr
@@ -20,7 +20,7 @@ module Scry
       analyzer = ParseAnalyzer.new(workspace, text_document)
       results = analyzer.run
       publishable_diagnostic = results.first
-      params = publishable_diagnostic.params.as(PublishDiagnosticsParams)
+      params = publishable_diagnostic.params.as(Protocol::PublishDiagnosticsParams)
       params.diagnostics.empty?.should be_false
     end
   end

--- a/spec/scry/protocol/void_params_spec.cr
+++ b/spec/scry/protocol/void_params_spec.cr
@@ -1,23 +1,21 @@
 require "../../spec_helper"
 
-module Scry
-  module Protocol
-    describe VoidParams do
-      it "creates from json" do
-        void_params = VoidParams.from_json("{}")
-        void_params.is_a?(VoidParams).should be_true
-      end
+module Scry::Protocol
+  describe VoidParams do
+    it "creates from json" do
+      void_params = VoidParams.from_json("{}")
+      void_params.is_a?(VoidParams).should be_true
+    end
 
-      it "raises a JSON::ParseException if non empty JSON is supplied" do
-        expect_raises(JSON::ParseException) do
-          void_params = VoidParams.from_json(%({ "key": "value" }))
-        end
+    it "raises a JSON::ParseException if non empty JSON is supplied" do
+      expect_raises(JSON::ParseException) do
+        void_params = VoidParams.from_json(%({ "key": "value" }))
       end
+    end
 
-      it "will render as JSON" do
-        void_params = VoidParams.from_json("{}")
-        void_params.to_json.should eq("{}")
-      end
+    it "will render as JSON" do
+      void_params = VoidParams.from_json("{}")
+      void_params.to_json.should eq("{}")
     end
   end
 end

--- a/spec/scry/protocol/void_params_spec.cr
+++ b/spec/scry/protocol/void_params_spec.cr
@@ -1,21 +1,23 @@
 require "../../spec_helper"
 
 module Scry
-  describe VoidParams do
-    it "creates from json" do
-      void_params = VoidParams.from_json("{}")
-      void_params.is_a?(VoidParams).should be_true
-    end
-
-    it "raises a JSON::ParseException if non empty JSON is supplied" do
-      expect_raises(JSON::ParseException) do
-        void_params = VoidParams.from_json(%({ "key": "value" }))
+  module Protocol
+    describe VoidParams do
+      it "creates from json" do
+        void_params = VoidParams.from_json("{}")
+        void_params.is_a?(VoidParams).should be_true
       end
-    end
 
-    it "will render as JSON" do
-      void_params = VoidParams.from_json("{}")
-      void_params.to_json.should eq("{}")
+      it "raises a JSON::ParseException if non empty JSON is supplied" do
+        expect_raises(JSON::ParseException) do
+          void_params = VoidParams.from_json(%({ "key": "value" }))
+        end
+      end
+
+      it "will render as JSON" do
+        void_params = VoidParams.from_json("{}")
+        void_params.to_json.should eq("{}")
+      end
     end
   end
 end

--- a/spec/scry/symbol_spec.cr
+++ b/spec/scry/symbol_spec.cr
@@ -6,7 +6,7 @@ module Scry
       text_document = TextDocument.new("uri", [""])
       processor = SymbolProcessor.new(text_document)
       symbols = processor.run
-      symbols.should be_a(Array(SymbolInformation))
+      symbols.should be_a(Array(Protocol::SymbolInformation))
     end
 
     it "returns Class symbols" do
@@ -14,7 +14,7 @@ module Scry
       processor = SymbolProcessor.new(text_document)
       symbols = processor.run
       result = symbols.first
-      result.kind.should be_a(SymbolKind::Class)
+      result.kind.should be_a(Protocol::SymbolKind::Class)
     end
 
     it "returns Struct symbols as a Class" do
@@ -22,7 +22,7 @@ module Scry
       processor = SymbolProcessor.new(text_document)
       symbols = processor.run
       result = symbols.first
-      result.kind.should be_a(SymbolKind::Class)
+      result.kind.should be_a(Protocol::SymbolKind::Class)
     end
 
     it "returns Module symbols" do
@@ -30,7 +30,7 @@ module Scry
       processor = SymbolProcessor.new(text_document)
       symbols = processor.run
       result = symbols.first
-      result.kind.should be_a(SymbolKind::Module)
+      result.kind.should be_a(Protocol::SymbolKind::Module)
     end
 
     it "returns Method symbols" do
@@ -38,7 +38,7 @@ module Scry
       processor = SymbolProcessor.new(text_document)
       symbols = processor.run
       result = symbols.first
-      result.kind.should be_a(SymbolKind::Method)
+      result.kind.should be_a(Protocol::SymbolKind::Method)
     end
 
     it "returns instance vars as Variable symbols" do
@@ -46,7 +46,7 @@ module Scry
       processor = SymbolProcessor.new(text_document)
       symbols = processor.run
       result = symbols.first
-      result.kind.should be_a(SymbolKind::Variable)
+      result.kind.should be_a(Protocol::SymbolKind::Variable)
     end
 
     describe "Property" do
@@ -55,7 +55,7 @@ module Scry
         processor = SymbolProcessor.new(text_document)
         symbols = processor.run
         result = symbols[1]
-        result.kind.should be_a(SymbolKind::Property)
+        result.kind.should be_a(Protocol::SymbolKind::Property)
       end
 
       it "returns setters as Property symbols" do
@@ -63,7 +63,7 @@ module Scry
         processor = SymbolProcessor.new(text_document)
         symbols = processor.run
         result = symbols[1]
-        result.kind.should be_a(SymbolKind::Property)
+        result.kind.should be_a(Protocol::SymbolKind::Property)
       end
 
       it "returns properties as Property symbols" do
@@ -71,7 +71,7 @@ module Scry
         processor = SymbolProcessor.new(text_document)
         symbols = processor.run
         result = symbols[1]
-        result.kind.should be_a(SymbolKind::Property)
+        result.kind.should be_a(Protocol::SymbolKind::Property)
       end
     end
 
@@ -81,7 +81,7 @@ module Scry
         processor = SymbolProcessor.new(text_document)
         symbols = processor.run
         result = symbols.first
-        result.kind.should be_a(SymbolKind::Constant)
+        result.kind.should be_a(Protocol::SymbolKind::Constant)
       end
 
       it "returns alias as Constant symbols" do
@@ -89,7 +89,7 @@ module Scry
         processor = SymbolProcessor.new(text_document)
         symbols = processor.run
         result = symbols.first
-        result.kind.should be_a(SymbolKind::Constant)
+        result.kind.should be_a(Protocol::SymbolKind::Constant)
       end
     end
 
@@ -104,14 +104,14 @@ module Scry
         processor = WorkspaceSymbolProcessor.new(ROOT_PATH, "saluto")
         symbols = processor.run
         result = symbols.first
-        result.kind.should be_a(SymbolKind::Method)
+        result.kind.should be_a(Protocol::SymbolKind::Method)
       end
 
       it "return stdlib symbol with query match for initialize" do
         processor = WorkspaceSymbolProcessor.new(ROOT_PATH, "initialize")
         symbols = processor.run
         result = symbols.first
-        result.kind.should be_a(SymbolKind::Method)
+        result.kind.should be_a(Protocol::SymbolKind::Method)
       end
     end
   end

--- a/spec/scry/update_config_spec.cr
+++ b/spec/scry/update_config_spec.cr
@@ -6,7 +6,7 @@ module Scry
       workspace = Workspace.new("/foo", 1.to_i64, 10)
       updater = UpdateConfig.new(
         workspace,
-        DidChangeConfigurationParams.from_json(
+        Protocol::DidChangeConfigurationParams.from_json(
           JSON.build do |params|
             params.object do
               params.field "settings" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "../src/scry/protocol"
 require "../src/scry/**"
 require "./protocol_helper"
 

--- a/src/scry.cr
+++ b/src/scry.cr
@@ -25,7 +25,7 @@ module Scry
         request = Message.new(content).parse
         results = context.dispatch(request)
       rescue ex
-        results = [ResponseMessage.new(ex)]
+        results = [Protocol::ResponseMessage.new(ex)]
       ensure
         response = [results].flatten.compact
         client.send_message(response)

--- a/src/scry.cr
+++ b/src/scry.cr
@@ -1,3 +1,4 @@
+require "./scry/protocol"
 require "./scry/log"
 require "./scry/request"
 require "./scry/context"

--- a/src/scry/client.cr
+++ b/src/scry/client.cr
@@ -4,20 +4,20 @@ require "./protocol/notification_message"
 
 module Scry
   class Client
-    alias ClientMessage = Initialize | ResponseMessage | NotificationMessage
+    alias ClientMessage = Protocol::Initialize | Protocol::ResponseMessage | Protocol::NotificationMessage
 
     getter io
 
     def initialize(@io : IO)
     end
 
-    def send(method_name : String, params : NotificationType)
-      notification_message = NotificationMessage.new(method_name, params)
+    def send(method_name : String, params : Protocol::NotificationType)
+      notification_message = Protocol::NotificationMessage.new(method_name, params)
       send_message(notification_message)
     end
 
-    def send(method_name : String, params : ResponseTypes)
-      response_message = ResponseMessage.new(method_name, params)
+    def send(method_name : String, params : Protocol::ResponseTypes)
+      response_message = Protocol::ResponseMessage.new(method_name, params)
       send_message(response_message)
     end
 

--- a/src/scry/client.cr
+++ b/src/scry/client.cr
@@ -1,7 +1,3 @@
-require "./protocol/initialize"
-require "./protocol/response_message"
-require "./protocol/notification_message"
-
 module Scry
   class Client
     alias ClientMessage = Protocol::Initialize | Protocol::ResponseMessage | Protocol::NotificationMessage

--- a/src/scry/completion/class_module_context.cr
+++ b/src/scry/completion/class_module_context.cr
@@ -12,10 +12,10 @@ module Scry::Completion
           label = label[(target_header_index + 1)..-1]
         end
 
-        CompletionItem.new(
+        Protocol::CompletionItem.new(
           label: label,
           insert_text: label,
-          kind: CompletionItemKind::Class,
+          kind: Protocol::CompletionItemKind::Class,
           detail: label,
           data: nil
         )

--- a/src/scry/completion/context.cr
+++ b/src/scry/completion/context.cr
@@ -1,5 +1,5 @@
 module Scry::Completion
   abstract class Context
-    abstract def find : Array(CompletionItem)
+    abstract def find : Array(Protocol::CompletionItem)
   end
 end

--- a/src/scry/completion/instance_variable_context.cr
+++ b/src/scry/completion/instance_variable_context.cr
@@ -6,12 +6,12 @@ module Scry::Completion
     def find
       # to_completion_items(["Results", "And", "more", "results"])
       # TODO implement instance variable completion
-      [] of CompletionItem
+      [] of Protocol::CompletionItem
     end
 
     def to_completion_items(results : Array(String))
       results.map do |res|
-        CompletionItem.new(res, CompletionItemKind::Variable, res)
+        Protocol::CompletionItem.new(res, Protocol::CompletionItemKind::Variable, res)
       end
     end
   end

--- a/src/scry/completion/method_call_context.cr
+++ b/src/scry/completion/method_call_context.cr
@@ -54,10 +54,10 @@ module Scry::Completion
 
     def to_completion_items(results : Array(MethodDBEntry))
       results.map do |res|
-        CompletionItem.new(res.name,
-          CompletionItemKind::Method,
+        Protocol::CompletionItem.new(res.name,
+          Protocol::CompletionItemKind::Method,
           "#{res.name}#{res.signature}",
-          MethodCallContextData.new(res.file_path, res.location))
+          Protocol::MethodCallContextData.new(res.file_path, res.location))
       end
     end
   end

--- a/src/scry/completion/require_module_context.cr
+++ b/src/scry/completion/require_module_context.cr
@@ -22,12 +22,12 @@ module Scry::Completion
         label = File.directory?(path) ? File.basename(path) + "/" : File.basename(path, ".cr")
         insert_text = label
         root_path = paths.first
-        CompletionItem.new(
+        Protocol::CompletionItem.new(
           label: label,
           insert_text: insert_text,
-          kind: CompletionItemKind::Module,
+          kind: Protocol::CompletionItemKind::Module,
           detail: label,
-          data: RequireModuleContextData.new(path)
+          data: Protocol::RequireModuleContextData.new(path)
         )
       end
     end

--- a/src/scry/completion_provider.cr
+++ b/src/scry/completion_provider.cr
@@ -5,7 +5,7 @@ require "./completion/*"
 module Scry
   class UnrecognizedContext < Completion::Context
     def find
-      [] of CompletionItem
+      [] of Protocol::CompletionItem
     end
   end
 
@@ -15,7 +15,7 @@ module Scry
     REQUIRE_MODULE_REGEX    = /require\s*\"(?<import>[a-zA-Z\/._]*)$/
     CLASS_NAME_REGEX        = /(?<target>[A-Z][a-zA-Z_:]*)$/
 
-    def initialize(@text_document : TextDocument, @context : CompletionContext | Nil, @position : Position, @method_db : Completion::MethodDB)
+    def initialize(@text_document : TextDocument, @context : Protocol::CompletionContext | Nil, @position : Protocol::Position, @method_db : Completion::MethodDB)
     end
 
     def run

--- a/src/scry/completion_resolver.cr
+++ b/src/scry/completion_resolver.cr
@@ -1,21 +1,21 @@
 module Scry
   class CompletionResolver
-    def initialize(@id : Int32, @completionItem : CompletionItem)
+    def initialize(@id : Int32, @completionItem : Protocol::CompletionItem)
     end
 
     def run
       data = @completionItem.data
       case data
-      when RequireModuleContextData
+      when Protocol::RequireModuleContextData
         file = File.new data.path
         doc = file.each_line.first(5).join("\n")
-        @completionItem.documentation = MarkupContent.new("markdown", "```crystal\n#{doc}\n```")
+        @completionItem.documentation = Protocol::MarkupContent.new("markdown", "```crystal\n#{doc}\n```")
         @completionItem
-      when MethodCallContextData
+      when Protocol::MethodCallContextData
         file = File.new data.path
         line = data.location.not_nil!.split(":")[1].to_i
         lines = file.each_line.first(line - 1).to_a.reverse.take_while(&.match /^\s*#/).map { |e| e.gsub(/^\s*#/, "") }.reverse.join("\n")
-        @completionItem.documentation = MarkupContent.new("markdown", lines)
+        @completionItem.documentation = Protocol::MarkupContent.new("markdown", lines)
         @completionItem
       else
         @completionItem

--- a/src/scry/formatter.cr
+++ b/src/scry/formatter.cr
@@ -21,12 +21,12 @@ module Scry
         old_lines = source.split('\n')
         max_size = [source.size, result.size].max # => max amount of characters
 
-        range = Range.new(
-          Position.new(0, 0),
-          Position.new(old_lines.size, max_size) # => Max column posible to replace old column
+        range = Protocol::Range.new(
+          Protocol::Position.new(0, 0),
+          Protocol::Position.new(old_lines.size, max_size) # => Max column posible to replace old column
         )
 
-        ResponseMessage.new(@text_document.id, [TextEdit.new(range, result)])
+        Protocol::ResponseMessage.new(@text_document.id, [Protocol::TextEdit.new(range, result)])
       end
     rescue ex
       Log.logger.error("A error was found while formatting\n#{ex}\n#{result}")

--- a/src/scry/formatter.cr
+++ b/src/scry/formatter.cr
@@ -2,8 +2,6 @@ require "compiler/crystal/formatter"
 
 require "./workspace"
 require "./text_document"
-require "./protocol/text_edit"
-require "./protocol/response_message"
 
 module Scry
   struct Formatter

--- a/src/scry/hover_provider.cr
+++ b/src/scry/hover_provider.cr
@@ -47,7 +47,7 @@ module Scry
         hover_response
       when HoverResponse
         if contexts = response.contexts
-          response_with(contexts, Range.new(position, position))
+          response_with(contexts, Protocol::Range.new(position, position))
         else
           hover_response
         end
@@ -57,15 +57,15 @@ module Scry
       hover_response
     end
 
-    def hover_response(context = Hover.new(MarkupContent.new("", "")))
-      ResponseMessage.new(@text_document.id, context)
+    def hover_response(context = Protocol::Hover.new(Protocol::MarkupContent.new("", "")))
+      Protocol::ResponseMessage.new(@text_document.id, context)
     end
 
     # NOTE: this Would be configurable in the future with scry.yml
     private def response_with(contexts, range)
       content = vertical_align(contexts)
       # content = horizontal_align(contexts)
-      hover_response(Hover.new(MarkupContent.new("markdown", content), range))
+      hover_response(Protocol::Hover.new(Protocol::MarkupContent.new("markdown", content), range))
     end
 
     # Aligns context output vertically. By example:

--- a/src/scry/hover_provider.cr
+++ b/src/scry/hover_provider.cr
@@ -1,6 +1,4 @@
 require "./log"
-require "./protocol/location"
-require "./protocol/hover"
 require "./build_failure"
 require "./tool_helper"
 

--- a/src/scry/implementations.cr
+++ b/src/scry/implementations.cr
@@ -1,5 +1,4 @@
 require "./log"
-require "./protocol/location"
 require "./build_failure"
 require "./tool_helper"
 

--- a/src/scry/implementations.cr
+++ b/src/scry/implementations.cr
@@ -66,15 +66,15 @@ module Scry
       implementation_response
     end
 
-    def implementation_response(locations = [] of Location)
-      ResponseMessage.new(@text_document.id, locations)
+    def implementation_response(locations = [] of Protocol::Location)
+      Protocol::ResponseMessage.new(@text_document.id, locations)
     end
 
     private def response_with(implementations)
       locations = implementations.map do |item|
-        pos = Position.new(item.line - 1, item.column - 1)
-        range = Range.new(pos, pos)
-        Location.new("file://" + item.filename, range)
+        pos = Protocol::Position.new(item.line - 1, item.column - 1)
+        range = Protocol::Range.new(pos, pos)
+        Protocol::Location.new("file://" + item.filename, range)
       end
       implementation_response(locations)
     end

--- a/src/scry/initializer.cr
+++ b/src/scry/initializer.cr
@@ -5,7 +5,7 @@ require "./protocol/server_capabilities"
 
 module Scry
   struct Initializer
-    def initialize(params : InitializeParams, @msg_id : Int32)
+    def initialize(params : Protocol::InitializeParams, @msg_id : Int32)
       @workspace = Workspace.new(
         root_uri: params.root_path || params.root_uri.to_s.sub("file://", ""),
         process_id: params.process_id,
@@ -20,7 +20,7 @@ module Scry
     end
 
     private def response
-      Initialize.new(@msg_id)
+      Protocol::Initialize.new(@msg_id)
     end
   end
 end

--- a/src/scry/initializer.cr
+++ b/src/scry/initializer.cr
@@ -1,7 +1,5 @@
 require "./log"
 require "./workspace"
-require "./protocol/initialize_params"
-require "./protocol/server_capabilities"
 
 module Scry
   struct Initializer

--- a/src/scry/log.cr
+++ b/src/scry/log.cr
@@ -14,15 +14,15 @@ module Scry
       private def write(severity, datetime, progname, message)
         message_type = case severity
                        when INFO
-                         MessageType::Info
+                         Protocol::MessageType::Info
                        when WARN
-                         MessageType::Warning
+                         Protocol::MessageType::Warning
                        when ERROR, FATAL
-                         MessageType::Error
+                         Protocol::MessageType::Error
                        else
-                         MessageType::Log
+                         Protocol::MessageType::Log
                        end
-        @client.send("window/logMessage", LogMessageParams.new(message_type, message.to_s))
+        @client.send("window/logMessage", Protocol::LogMessageParams.new(message_type, message.to_s))
       end
     end
   end

--- a/src/scry/log.cr
+++ b/src/scry/log.cr
@@ -1,6 +1,5 @@
 require "logger"
 require "./client"
-require "./protocol/log_message_params"
 
 module Scry
   module Log

--- a/src/scry/message.cr
+++ b/src/scry/message.cr
@@ -5,7 +5,7 @@ module Scry
   class InvalidContentError < Exception
   end
 
-  alias ProtocolMessage = RequestMessage | NotificationMessage
+  alias ProtocolMessage = Protocol::RequestMessage | Protocol::NotificationMessage
 
   struct Message
     def initialize(@json : String)

--- a/src/scry/message.cr
+++ b/src/scry/message.cr
@@ -1,6 +1,3 @@
-require "./protocol/notification_message"
-require "./protocol/request_message"
-
 module Scry
   class InvalidContentError < Exception
   end

--- a/src/scry/protocol.cr
+++ b/src/scry/protocol.cr
@@ -1,0 +1,1 @@
+require "./protocol/*"

--- a/src/scry/protocol/cancel_params.cr
+++ b/src/scry/protocol/cancel_params.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   struct CancelParams
     JSON.mapping({
       id: Int32 | String,

--- a/src/scry/protocol/completion_context.cr
+++ b/src/scry/protocol/completion_context.cr
@@ -1,4 +1,4 @@
-module Scry
+module Scry::Protocol
   enum CompletionTriggerKind
     Invoked          = 1
     TriggerCharacter = 2

--- a/src/scry/protocol/completion_item.cr
+++ b/src/scry/protocol/completion_item.cr
@@ -1,6 +1,6 @@
 require "./markup_content"
 
-module Scry
+module Scry::Protocol
   enum CompletionItemKind
     Text          =  1
     Method        =  2

--- a/src/scry/protocol/completion_params.cr
+++ b/src/scry/protocol/completion_params.cr
@@ -1,8 +1,4 @@
-require "./text_document_identifier"
-require "./position"
-require "./completion_context"
-
-module Scry
+module Scry::Protocol
   struct CompletionParams
     JSON.mapping({
       text_document: {type: TextDocumentIdentifier, key: "textDocument"},

--- a/src/scry/protocol/diagnostic.cr
+++ b/src/scry/protocol/diagnostic.cr
@@ -1,7 +1,4 @@
-require "./range"
-require "./position"
-
-module Scry
+module Scry::Protocol
   enum DiagnosticSeverity
     Error       = 1
     Warning     = 2

--- a/src/scry/protocol/did_change_configuration_params.cr
+++ b/src/scry/protocol/did_change_configuration_params.cr
@@ -1,6 +1,4 @@
-require "./settings"
-
-module Scry
+module Scry::Protocol
   struct DidChangeConfigurationParams
     JSON.mapping({
       settings: Settings,

--- a/src/scry/protocol/did_change_text_document_params.cr
+++ b/src/scry/protocol/did_change_text_document_params.cr
@@ -1,7 +1,4 @@
-require "./versioned_text_document_identifier"
-require "./text_document_content_change_event"
-
-module Scry
+module Scry::Protocol
   struct DidChangeTextDocumentParams
     JSON.mapping({
       text_document:   {type: VersionedTextDocumentIdentifier, key: "textDocument"},

--- a/src/scry/protocol/did_change_watched_files_params.cr
+++ b/src/scry/protocol/did_change_watched_files_params.cr
@@ -1,6 +1,4 @@
-require "./file_event"
-
-module Scry
+module Scry::Protocol
   struct DidChangeWatchedFilesParams
     JSON.mapping({
       changes: Array(FileEvent),

--- a/src/scry/protocol/did_open_text_document_params.cr
+++ b/src/scry/protocol/did_open_text_document_params.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   struct DidOpenTextDocumentParams
     JSON.mapping({
       text_document: {type: TextDocumentItem, key: "textDocument"},

--- a/src/scry/protocol/document_formatting_params.cr
+++ b/src/scry/protocol/document_formatting_params.cr
@@ -1,6 +1,4 @@
-require "./formatting_options"
-
-module Scry
+module Scry::Protocol
   struct DocumentFormattingParams
     JSON.mapping({
       text_document: {type: TextDocumentIdentifier, key: "textDocument"},

--- a/src/scry/protocol/file_event.cr
+++ b/src/scry/protocol/file_event.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   enum FileEventType
     Created = 1
     Changed = 2

--- a/src/scry/protocol/formatting_options.cr
+++ b/src/scry/protocol/formatting_options.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   struct FormattingOptions
     JSON.mapping({
       tabSize:      Int32,

--- a/src/scry/protocol/hover.cr
+++ b/src/scry/protocol/hover.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   struct Hover
     JSON.mapping({
       contents: MarkupContent,

--- a/src/scry/protocol/initialize.cr
+++ b/src/scry/protocol/initialize.cr
@@ -1,6 +1,4 @@
-require "./initialize_result"
-
-module Scry
+module Scry::Protocol
   struct Initialize
     JSON.mapping(
       jsonrpc: String,

--- a/src/scry/protocol/initialize_params.cr
+++ b/src/scry/protocol/initialize_params.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   struct InitializeParams
     JSON.mapping({
       process_id:   {type: Int64 | Int32 | Nil, key: "processId", nilable: true},

--- a/src/scry/protocol/initialize_result.cr
+++ b/src/scry/protocol/initialize_result.cr
@@ -1,6 +1,4 @@
-require "./server_capabilities"
-
-module Scry
+module Scry::Protocol
   struct InitializeResult
     JSON.mapping(
       capabilities: ServerCapabilities

--- a/src/scry/protocol/location.cr
+++ b/src/scry/protocol/location.cr
@@ -1,6 +1,4 @@
-require "./range"
-
-module Scry
+module Scry::Protocol
   struct Location
     JSON.mapping({
       uri:   String,

--- a/src/scry/protocol/log_message_params.cr
+++ b/src/scry/protocol/log_message_params.cr
@@ -1,5 +1,4 @@
 require "json"
-require "./message_type"
 
 module Scry::Protocol
   struct LogMessageParams

--- a/src/scry/protocol/log_message_params.cr
+++ b/src/scry/protocol/log_message_params.cr
@@ -1,7 +1,7 @@
 require "json"
 require "./message_type"
 
-module Scry
+module Scry::Protocol
   struct LogMessageParams
     JSON.mapping({
       type:    MessageType,

--- a/src/scry/protocol/markup_content.cr
+++ b/src/scry/protocol/markup_content.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   struct MarkupContent
     JSON.mapping({
       kind:  String,

--- a/src/scry/protocol/message_type.cr
+++ b/src/scry/protocol/message_type.cr
@@ -1,4 +1,4 @@
-module Scry
+module Scry::Protocol
   enum MessageType
     Error   = 1
     Warning = 2

--- a/src/scry/protocol/notification_message.cr
+++ b/src/scry/protocol/notification_message.cr
@@ -1,16 +1,4 @@
-require "./did_change_configuration_params"
-require "./did_change_text_document_params"
-require "./did_change_watched_files_params"
-require "./did_open_text_document_params"
-require "./text_document_params"
-require "./document_formatting_params"
-require "./publish_diagnostics_params"
-require "./void_params"
-require "./trace"
-require "./cancel_params"
-require "./log_message_params"
-
-module Scry
+module Scry::Protocol
   alias NotificationType = (DidChangeConfigurationParams |
                             DidChangeTextDocumentParams |
                             DidChangeWatchedFilesParams |

--- a/src/scry/protocol/position.cr
+++ b/src/scry/protocol/position.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   struct Position
     JSON.mapping({
       line:      Int32,

--- a/src/scry/protocol/publish_diagnostics_params.cr
+++ b/src/scry/protocol/publish_diagnostics_params.cr
@@ -1,6 +1,4 @@
-require "./diagnostic"
-
-module Scry
+module Scry::Protocol
   struct PublishDiagnosticsParams
     JSON.mapping({
       uri:         String,

--- a/src/scry/protocol/range.cr
+++ b/src/scry/protocol/range.cr
@@ -1,6 +1,4 @@
-require "./position"
-
-module Scry
+module Scry::Protocol
   struct Range
     JSON.mapping({
       start: Position,

--- a/src/scry/protocol/request_message.cr
+++ b/src/scry/protocol/request_message.cr
@@ -1,8 +1,4 @@
-require "./initialize_params"
-require "./text_document_position_params"
-require "./workspace_symbol_params"
-
-module Scry
+module Scry::Protocol
   struct RequestMessage
     alias RequestType = (TextDocumentPositionParams |
                          InitializeParams |

--- a/src/scry/protocol/response_error.cr
+++ b/src/scry/protocol/response_error.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   enum ErrorCodes
     # Defined by JSON RPC
     ParseError           = -32700

--- a/src/scry/protocol/response_message.cr
+++ b/src/scry/protocol/response_message.cr
@@ -1,11 +1,4 @@
-require "./response_error"
-require "./text_edit"
-require "./location"
-require "./symbol_information"
-require "./completion_item"
-require "./hover"
-
-module Scry
+module Scry::Protocol
   # Add a response type when needed
   alias ResponseTypes = Array(TextEdit) | Array(Location) | Array(SymbolInformation) | Array(CompletionItem) | CompletionItem | Hover
 

--- a/src/scry/protocol/server_capabilities.cr
+++ b/src/scry/protocol/server_capabilities.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   enum TextDocumentSyncKind
     None
     Full

--- a/src/scry/protocol/settings.cr
+++ b/src/scry/protocol/settings.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   alias Settings = SettingsCrystalIDE | SettingsCrystalLang
 
   struct Customizations

--- a/src/scry/protocol/symbol_information.cr
+++ b/src/scry/protocol/symbol_information.cr
@@ -1,7 +1,7 @@
 require "json"
 require "./location"
 
-module Scry
+module Scry::Protocol
   enum SymbolKind
     File        =  1
     Module      =  2

--- a/src/scry/protocol/symbol_information.cr
+++ b/src/scry/protocol/symbol_information.cr
@@ -1,5 +1,4 @@
 require "json"
-require "./location"
 
 module Scry::Protocol
   enum SymbolKind

--- a/src/scry/protocol/text_document_content_change_event.cr
+++ b/src/scry/protocol/text_document_content_change_event.cr
@@ -1,6 +1,4 @@
-require "./range"
-
-module Scry
+module Scry::Protocol
   struct TextDocumentContentChangeEvent
     JSON.mapping({
       range:        Range?,

--- a/src/scry/protocol/text_document_identifier.cr
+++ b/src/scry/protocol/text_document_identifier.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   struct TextDocumentIdentifier
     JSON.mapping({
       uri: String,

--- a/src/scry/protocol/text_document_params.cr
+++ b/src/scry/protocol/text_document_params.cr
@@ -1,6 +1,4 @@
 require "json"
-require "./text_document_identifier"
-require "./versioned_text_document_identifier"
 
 module Scry::Protocol
   struct TextDocumentParams

--- a/src/scry/protocol/text_document_params.cr
+++ b/src/scry/protocol/text_document_params.cr
@@ -2,7 +2,7 @@ require "json"
 require "./text_document_identifier"
 require "./versioned_text_document_identifier"
 
-module Scry
+module Scry::Protocol
   struct TextDocumentParams
     JSON.mapping({
       text_document: {type: (TextDocumentIdentifier | VersionedTextDocumentIdentifier), key: "textDocument"},

--- a/src/scry/protocol/text_document_position_params.cr
+++ b/src/scry/protocol/text_document_position_params.cr
@@ -1,8 +1,4 @@
-require "./text_document_identifier"
-require "./position"
-require "./completion_context"
-
-module Scry
+module Scry::Protocol
   struct TextDocumentPositionParams
     JSON.mapping({
       text_document: {type: TextDocumentIdentifier, key: "textDocument"},

--- a/src/scry/protocol/text_edit.cr
+++ b/src/scry/protocol/text_edit.cr
@@ -1,6 +1,4 @@
-require "./range"
-
-module Scry
+module Scry::Protocol
   struct TextEdit
     JSON.mapping(
       range: Range,

--- a/src/scry/protocol/trace.cr
+++ b/src/scry/protocol/trace.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   # The initial trace setting. If omitted trace is disabled ('off')
   # 'off' | 'messages' | 'verbose'
   struct Trace

--- a/src/scry/protocol/versioned_text_document_identifier.cr
+++ b/src/scry/protocol/versioned_text_document_identifier.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   struct VersionedTextDocumentIdentifier
     JSON.mapping({
       uri:     String,

--- a/src/scry/protocol/void_params.cr
+++ b/src/scry/protocol/void_params.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   struct VoidParams
     def initialize(pull : JSON::PullParser)
       pull.read_begin_object

--- a/src/scry/protocol/workspace_symbol_params.cr
+++ b/src/scry/protocol/workspace_symbol_params.cr
@@ -1,6 +1,6 @@
 require "json"
 
-module Scry
+module Scry::Protocol
   struct WorkspaceSymbolParams
     JSON.mapping({
       query: String,

--- a/src/scry/publish_diagnostic.cr
+++ b/src/scry/publish_diagnostic.cr
@@ -1,6 +1,3 @@
-require "./protocol/publish_diagnostics_params"
-require "./protocol/notification_message"
-require "./protocol/diagnostic"
 require "./build_failure"
 require "./workspace"
 

--- a/src/scry/publish_diagnostic.cr
+++ b/src/scry/publish_diagnostic.cr
@@ -17,11 +17,11 @@ module Scry
     end
 
     private def notification(params)
-      NotificationMessage.new("textDocument/publishDiagnostics", params)
+      Protocol::NotificationMessage.new("textDocument/publishDiagnostics", params)
     end
 
     private def unclean(file, diagnostics)
-      params = PublishDiagnosticsParams.new(file, diagnostics)
+      params = Protocol::PublishDiagnosticsParams.new(file, diagnostics)
       notification(params)
     end
 
@@ -38,16 +38,16 @@ module Scry
     end
 
     def clean(uri = @uri)
-      params = PublishDiagnosticsParams.new(uri, [] of Diagnostic)
+      params = Protocol::PublishDiagnosticsParams.new(uri, [] of Protocol::Diagnostic)
       notification(params)
     end
 
-    def from(ex) : Array(NotificationMessage)
+    def from(ex) : Array(Protocol::NotificationMessage)
       build_failures = Array(BuildFailure).from_json(ex)
       build_failures
         .uniq
         .first(@workspace.max_number_of_problems)
-        .map { |bf| Diagnostic.new(bf) }
+        .map { |bf| Protocol::Diagnostic.new(bf) }
         .group_by(&.uri)
         .select { |file, diagnostics| !file.ends_with?(".scry_main.cr") }
         .map do |file, diagnostics|

--- a/src/scry/symbol.cr
+++ b/src/scry/symbol.cr
@@ -1,5 +1,4 @@
 require "compiler/crystal/syntax"
-require "./protocol/workspace_symbol_params"
 
 module Scry
   class SymbolVisitor < Crystal::Visitor

--- a/src/scry/symbol.cr
+++ b/src/scry/symbol.cr
@@ -50,7 +50,7 @@ module Scry
     end
 
     def visit(node : Crystal::Alias)
-      process_node node, node.name.names.last, SymbolKind::Constant
+      process_node node, node.name.names.last, Protocol::SymbolKind::Constant
       true
     end
 

--- a/src/scry/symbol.cr
+++ b/src/scry/symbol.cr
@@ -7,46 +7,46 @@ module Scry
 
     def initialize(@document_uri : String)
       @container = [] of String
-      @symbols = [] of SymbolInformation
+      @symbols = [] of Protocol::SymbolInformation
     end
 
     def visit(node : Crystal::ClassDef)
-      process_node node, node.name.names.last, SymbolKind::Class
+      process_node node, node.name.names.last, Protocol::SymbolKind::Class
       @container << node.name.names.last
       true
     end
 
     def visit(node : Crystal::EnumDef)
-      process_node node, node.name.names.last, SymbolKind::Enum
+      process_node node, node.name.names.last, Protocol::SymbolKind::Enum
       @container << node.name.names.last
       true
     end
 
     def visit(node : Crystal::ModuleDef)
-      process_node node, node.name.names.last, SymbolKind::Module
+      process_node node, node.name.names.last, Protocol::SymbolKind::Module
       @container << node.name.names.last
       true
     end
 
     def visit(node : Crystal::Def)
-      process_node node, node.name, SymbolKind::Method
+      process_node node, node.name, Protocol::SymbolKind::Method
       false
     end
 
     def visit(node : Crystal::LibDef)
-      process_node node, node.name, SymbolKind::Package
+      process_node node, node.name, Protocol::SymbolKind::Package
       @container << node.name
       true
     end
 
     def visit(node : Crystal::StructOrUnionDef)
-      process_node node, node.name, SymbolKind::Class
+      process_node node, node.name, Protocol::SymbolKind::Class
       @container << node.name
       true
     end
 
     def visit(node : Crystal::FunDef)
-      process_node node, node.name, SymbolKind::Function
+      process_node node, node.name, Protocol::SymbolKind::Function
       true
     end
 
@@ -57,7 +57,7 @@ module Scry
 
     def visit(node : Crystal::Assign)
       if node.target.is_a?(Crystal::Path)
-        process_node node, node.target.as(Crystal::Path).names.last, SymbolKind::Constant
+        process_node node, node.target.as(Crystal::Path).names.last, Protocol::SymbolKind::Constant
       end
       true
     end
@@ -71,12 +71,12 @@ module Scry
     end
 
     def visit(node : Crystal::Var)
-      process_node node, node.name, SymbolKind::Property
+      process_node node, node.name, Protocol::SymbolKind::Property
       true
     end
 
     def visit(node : Crystal::InstanceVar)
-      process_node node, node.name, SymbolKind::Variable
+      process_node node, node.name, Protocol::SymbolKind::Variable
       true
     end
 
@@ -85,13 +85,13 @@ module Scry
       @container.pop?
     end
 
-    def process_node(node, name : String, kind : SymbolKind)
+    def process_node(node, name : String, kind : Protocol::SymbolKind)
       location = node.location
       return unless location
 
       line_number = location.line_number
       column_number = location.column_number
-      position = Position.new(line_number - 1, column_number - 1)
+      position = Protocol::Position.new(line_number - 1, column_number - 1)
 
       if end_location = node.end_location
         end_line_number = end_location.line_number
@@ -100,11 +100,11 @@ module Scry
         end_line_number = line_number
         end_column_number = column_number
       end
-      end_position = Position.new(end_line_number - 1, end_column_number - 1)
+      end_position = Protocol::Position.new(end_line_number - 1, end_column_number - 1)
 
-      range = Range.new(position, end_position)
-      location = Location.new(@document_uri, range)
-      @symbols << SymbolInformation.new(name, kind, location, @container.join("::"))
+      range = Protocol::Range.new(position, end_position)
+      location = Protocol::Location.new(@document_uri, range)
+      @symbols << Protocol::SymbolInformation.new(name, kind, location, @container.join("::"))
     end
   end
 
@@ -120,19 +120,19 @@ module Scry
       node.accept(visitor)
       visitor.symbols
     rescue
-      [] of SymbolInformation
+      [] of Protocol::SymbolInformation
     end
   end
 
   class WorkspaceSymbolProcessor
-    @@crystal_path_symbols : Array(SymbolInformation)?
+    @@crystal_path_symbols : Array(Protocol::SymbolInformation)?
 
     def initialize(@root_path : String, @query : String)
       @workspace_files = Dir.glob(File.join(root_path, "**", "*.cr"))
     end
 
     def run
-      return [] of SymbolInformation if @query.empty?
+      return [] of Protocol::SymbolInformation if @query.empty?
       self.class.search_symbols(@workspace_files, @query).concat(
         self.class.crystal_path_symbols.select(&.name.includes?(@query))
       )
@@ -146,7 +146,7 @@ module Scry
     end
 
     def self.search_symbols(files, query)
-      symbols = [] of SymbolInformation
+      symbols = [] of Protocol::SymbolInformation
       files.each do |file|
         processor = SymbolProcessor.new(TextDocument.new("file://#{file}"))
         symbols.concat processor.run.select(&.name.includes?(query))

--- a/src/scry/text_document.cr
+++ b/src/scry/text_document.cr
@@ -10,7 +10,7 @@ module Scry
     getter id : Int32 | Nil
     getter uri : String
     getter filename : String
-    getter position : Position?
+    getter position : Protocol::Position?
     property text : Array(String)
 
     def initialize(@uri, @text)
@@ -22,40 +22,40 @@ module Scry
       @text = [read_file]
     end
 
-    def initialize(params : DidOpenTextDocumentParams)
+    def initialize(params : Protocol::DidOpenTextDocumentParams)
       @uri = params.text_document.uri
       @filename = uri_to_filename
       @text = [params.text_document.text]
     end
 
     # Used by ParseAnalyzer
-    def initialize(change : DidChangeTextDocumentParams)
+    def initialize(change : Protocol::DidChangeTextDocumentParams)
       @uri = change.text_document.uri
       @filename = uri_to_filename
       @text = change.content_changes.map { |change| change.text }
     end
 
     # Used by Analyzer
-    def initialize(file_event : FileEvent)
+    def initialize(file_event : Protocol::FileEvent)
       @uri = file_event.uri
       @filename = uri_to_filename
       @text = [read_file]
     end
 
-    def initialize(params : DocumentFormattingParams, @id)
+    def initialize(params : Protocol::DocumentFormattingParams, @id)
       @uri = params.text_document.uri
       @filename = uri_to_filename
       @text = [""]
     end
 
-    def initialize(params : TextDocumentPositionParams, @id)
+    def initialize(params : Protocol::TextDocumentPositionParams, @id)
       @uri = params.text_document.uri
       @position = params.position
       @filename = uri_to_filename
       @text = [read_file]
     end
 
-    def initialize(params : TextDocumentParams, @id)
+    def initialize(params : Protocol::TextDocumentParams, @id)
       @uri = params.text_document.uri
       @filename = uri_to_filename
       @text = [read_file]

--- a/src/scry/text_document.cr
+++ b/src/scry/text_document.cr
@@ -1,10 +1,3 @@
-require "./protocol/file_event"
-require "./protocol/document_formatting_params"
-require "./protocol/did_open_text_document_params"
-require "./protocol/did_change_text_document_params"
-require "./protocol/did_change_watched_files_params"
-require "./protocol/did_change_configuration_params"
-
 module Scry
   struct TextDocument
     getter id : Int32 | Nil

--- a/src/scry/update_config.cr
+++ b/src/scry/update_config.cr
@@ -1,6 +1,5 @@
 require "./log"
 require "./workspace"
-require "./protocol/did_change_configuration_params"
 
 module Scry
   struct UpdateConfig

--- a/src/scry/update_config.cr
+++ b/src/scry/update_config.cr
@@ -12,7 +12,7 @@ module Scry
       "fatal" => Logger::FATAL,
     }
 
-    def initialize(@workspace : Workspace, @settings : DidChangeConfigurationParams)
+    def initialize(@workspace : Workspace, @settings : Protocol::DidChangeConfigurationParams)
     end
 
     def initialize(@workspace : Workspace, @settings)

--- a/src/scry/workspace.cr
+++ b/src/scry/workspace.cr
@@ -31,7 +31,7 @@ module Scry
       @open_files[file.filename] = {file, method_db}
     end
 
-    def put_file(params : DidOpenTextDocumentParams)
+    def put_file(params : Protocol::DidOpenTextDocumentParams)
       file = TextDocument.new(params)
       if @dependency_graph[file.filename]?
         file_dependencies = @dependency_graph[file.filename].descendants.map &.value
@@ -43,19 +43,19 @@ module Scry
       @open_files[file.filename] = {file, method_db}
     end
 
-    def update_file(params : DidChangeTextDocumentParams)
+    def update_file(params : Protocol::DidChangeTextDocumentParams)
       file = TextDocument.new params
       _, node = @open_files[file.filename]
       @open_files[file.filename] = {file, node}
     end
 
-    def drop_file(params : TextDocumentParams)
+    def drop_file(params : Protocol::TextDocumentParams)
       filename = TextDocument.uri_to_filename(params.text_document.uri)
       @open_files.delete(filename)
       @dependency_graph.delete(filename)
     end
 
-    def get_file(text_document : TextDocumentIdentifier)
+    def get_file(text_document : Protocol::TextDocumentIdentifier)
       filename = TextDocument.uri_to_filename(text_document.uri)
       @open_files[filename]
     end


### PR DESCRIPTION
This PR does two things to try and cleanup/organize the code some more.

- Adds the `Protocol` namespace, this should make things more clear about what is part of the LSP Protocol
- Adds `protocol.cr` and requires that in `scry.cr` instead of requiring all of the protocol files throughout the program