### PR TITLE
Update for Crystal v0.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.25.1
+FROM crystallang/crystal:0.26.0
 
 RUN apt-get update
 RUN apt-get clean

--- a/src/scry/symbol.cr
+++ b/src/scry/symbol.cr
@@ -51,7 +51,7 @@ module Scry
     end
 
     def visit(node : Crystal::Alias)
-      process_node node, node.name, SymbolKind::Constant
+      process_node node, node.name.names.last, SymbolKind::Constant
       true
     end
 


### PR DESCRIPTION
Small update for v0.26.0.  The name for `Alias` AST node is now a `Path`.