### PR TITLE
Decouple Workspace from Protocol

### DIFF
--- a/spec/scry/formatter_spec.cr
+++ b/spec/scry/formatter_spec.cr
@@ -19,7 +19,7 @@ module Scry
 
     it "check formatter on untitled file" do
       workspace = Workspace.new("root_uri", 0, 10)
-      workspace.put_file(Protocol::DidOpenTextDocumentParams.from_json(UNTITLED_FORMATTER_EXAMPLE))
+      workspace.put_file(TextDocument.new(Protocol::DidOpenTextDocumentParams.from_json(UNTITLED_FORMATTER_EXAMPLE)))
       text_document, empty_completion = workspace.open_files["untitled:Untitled-1"]
       format = Formatter.new(workspace, text_document)
       response = format.run

--- a/spec/scry/workspace_spec.cr
+++ b/spec/scry/workspace_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "tempfile"
 
 module Scry
   describe Workspace do
@@ -17,10 +18,72 @@ module Scry
       workspace.dependency_graph.each.to_a.size.should_not eq 1
     end
 
-    it ".update_file" do
+    describe ".put_file" do
+      it "adds a file and generates it's method db" do
+        source = Tempfile.new("test") # This will need to change w/ v0.27.0
+        File.write(source.path, "class A; def hello; end; end;")
+        text_document = TextDocument.new(source.path)
+
+        workspace = Workspace.new("root", 0, 10)
+        workspace.open_files[source.path]?.should be_nil
+
+        _, method_db = workspace.put_file(text_document)
+
+        workspace.open_files[source.path].should_not be_nil
+        method_db.db["A"].size.should eq(1)
+        method_db.db["A"][0].name.should eq("hello")
+      end
     end
 
-    it ".put_file" do
+    describe ".update_file" do
+      it "updates an existing file and it's method db" do
+        source = Tempfile.new("test") # This will need to change w/ v0.27.0
+        File.write(source.path, "class A; def hello; end; end;")
+        text_document = TextDocument.new(source.path)
+        workspace = Workspace.new("root", 0, 10)
+
+        workspace.put_file(text_document)
+        File.write(source.path, "class A; def hello2; end; end;")
+        text_document.text = [File.read(source.path)]
+
+        _, method_db = workspace.update_file(text_document)
+
+        workspace.open_files[source.path].should_not be_nil
+        method_db.db["A"].size.should eq(1)
+        method_db.db["A"][0].name.should eq("hello2")
+      end
+    end
+
+    describe ".drop_file" do
+      it "removes a file from the workspace" do
+        source = Tempfile.new("test") # This will need to change w/ v0.27.0
+        File.write(source.path, "class A; def hello; end; end;")
+        text_document = TextDocument.new(source.path)
+        workspace = Workspace.new("root", 0, 10)
+
+        _, method_db = workspace.put_file(text_document)
+        workspace.open_files[source.path].should_not be_nil
+
+        workspace.drop_file(text_document)
+        workspace.open_files[source.path]?.should be_nil
+      end
+    end
+
+    describe ".get_file" do
+      it "retrieves a file and its method db from the workspace" do
+        source = Tempfile.new("test") # This will need to change w/ v0.27.0
+        File.write(source.path, "class A; def hello; end; end;")
+        text_document = TextDocument.new(source.path)
+        workspace = Workspace.new("root", 0, 10)
+
+        _, method_db = workspace.put_file(text_document)
+        workspace.open_files[source.path].should_not be_nil
+
+        document, method_db = workspace.get_file(text_document)
+        document.filename.should eq(source.path)
+        method_db.db["A"].size.should eq(1)
+        method_db.db["A"][0].name.should eq("hello")
+      end
     end
   end
 end

--- a/spec/scry/workspace_spec.cr
+++ b/spec/scry/workspace_spec.cr
@@ -79,7 +79,7 @@ module Scry
         _, method_db = workspace.put_file(text_document)
         workspace.open_files[source.path].should_not be_nil
 
-        document, method_db = workspace.get_file(text_document)
+        document, method_db = workspace.get_file(text_document.filename)
         document.filename.should eq(source.path)
         method_db.db["A"].size.should eq(1)
         method_db.db["A"][0].name.should eq("hello")

--- a/spec/scry/workspace_spec.cr
+++ b/spec/scry/workspace_spec.cr
@@ -1,5 +1,4 @@
 require "../spec_helper"
-require "tempfile"
 
 module Scry
   describe Workspace do
@@ -20,7 +19,7 @@ module Scry
 
     describe ".put_file" do
       it "adds a file and generates it's method db" do
-        source = Tempfile.new("test") # This will need to change w/ v0.27.0
+        source = File.tempfile("test")
         File.write(source.path, "class A; def hello; end; end;")
         text_document = TextDocument.new(source.path)
 
@@ -37,7 +36,7 @@ module Scry
 
     describe ".update_file" do
       it "updates an existing file and it's method db" do
-        source = Tempfile.new("test") # This will need to change w/ v0.27.0
+        source = File.tempfile("test")
         File.write(source.path, "class A; def hello; end; end;")
         text_document = TextDocument.new(source.path)
         workspace = Workspace.new("root", 0, 10)
@@ -56,7 +55,7 @@ module Scry
 
     describe ".drop_file" do
       it "removes a file from the workspace" do
-        source = Tempfile.new("test") # This will need to change w/ v0.27.0
+        source = File.tempfile("test")
         File.write(source.path, "class A; def hello; end; end;")
         text_document = TextDocument.new(source.path)
         workspace = Workspace.new("root", 0, 10)
@@ -71,7 +70,7 @@ module Scry
 
     describe ".get_file" do
       it "retrieves a file and its method db from the workspace" do
-        source = Tempfile.new("test") # This will need to change w/ v0.27.0
+        source = File.tempfile("test")
         File.write(source.path, "class A; def hello; end; end;")
         text_document = TextDocument.new(source.path)
         workspace = Workspace.new("root", 0, 10)

--- a/src/scry/context.cr
+++ b/src/scry/context.cr
@@ -72,7 +72,7 @@ module Scry
         Log.logger.debug(response)
         response
       when "textDocument/completion"
-        text_document, method_db = @workspace.get_file(TextDocument.new(params, msg.id))
+        text_document, method_db = @workspace.get_file(TextDocument.uri_to_filename(params.text_document.uri))
         completion = CompletionProvider.new(text_document, params.context, params.position, method_db)
         results = completion.run
         response = Protocol::ResponseMessage.new(msg.id, results)

--- a/src/scry/context.cr
+++ b/src/scry/context.cr
@@ -72,7 +72,7 @@ module Scry
         Log.logger.debug(response)
         response
       when "textDocument/completion"
-        text_document, method_db = @workspace.get_file(params.text_document)
+        text_document, method_db = @workspace.get_file(TextDocument.new(params, msg.id))
         completion = CompletionProvider.new(text_document, params.context, params.position, method_db)
         results = completion.run
         response = Protocol::ResponseMessage.new(msg.id, results)
@@ -136,7 +136,7 @@ module Scry
     private def dispatch_notification(params : Protocol::TextDocumentParams, msg)
       case msg.method
       when "textDocument/didClose"
-        @workspace.drop_file(params)
+        @workspace.drop_file(TextDocument.new(params))
       end
       nil
     end
@@ -148,8 +148,8 @@ module Scry
     end
 
     private def dispatch_notification(params : Protocol::DidOpenTextDocumentParams, msg)
-      @workspace.put_file(params)
       text_document = TextDocument.new(params)
+      @workspace.put_file(text_document)
       unless text_document.in_memory?
         analyzer = Analyzer.new(@workspace, text_document)
         response = analyzer.run
@@ -158,8 +158,8 @@ module Scry
     end
 
     private def dispatch_notification(params : Protocol::DidChangeTextDocumentParams, msg)
-      @workspace.update_file(params)
       text_document = TextDocument.new(params)
+      @workspace.update_file(text_document)
       analyzer = ParseAnalyzer.new(@workspace, text_document)
       response = analyzer.run
       response

--- a/src/scry/text_document.cr
+++ b/src/scry/text_document.cr
@@ -48,18 +48,14 @@ module Scry
       @text = [read_file]
     end
 
-    def initialize(params : Protocol::TextDocumentParams, @id)
+    def initialize(params : Protocol::TextDocumentParams, @id = nil)
       @uri = params.text_document.uri
       @filename = uri_to_filename
       @text = [read_file]
     end
 
     def uri_to_filename
-      self.class.uri_to_filename(@uri)
-    end
-
-    def self.uri_to_filename(uri)
-      uri.sub(/^file:\/\/|^inmemory:\/\/|^git:\/\//, "")
+      @uri.sub(/^file:\/\/|^inmemory:\/\/|^git:\/\//, "")
     end
 
     def in_memory?

--- a/src/scry/text_document.cr
+++ b/src/scry/text_document.cr
@@ -55,7 +55,11 @@ module Scry
     end
 
     def uri_to_filename
-      @uri.sub(/^file:\/\/|^inmemory:\/\/|^git:\/\//, "")
+      self.class.uri_to_filename(@uri)
+    end
+
+    def self.uri_to_filename(uri)
+      uri.sub(/^file:\/\/|^inmemory:\/\/|^git:\/\//, "")
     end
 
     def in_memory?

--- a/src/scry/workspace.cr
+++ b/src/scry/workspace.cr
@@ -56,8 +56,8 @@ module Scry
       @dependency_graph.delete(text_document.filename)
     end
 
-    def get_file(text_document : TextDocument)
-      @open_files[text_document.filename]
+    def get_file(file_name)
+      @open_files[file_name]
     end
   end
 end

--- a/src/scry/workspace.cr
+++ b/src/scry/workspace.cr
@@ -43,8 +43,12 @@ module Scry
     end
 
     def update_file(text_document : TextDocument)
-      _, node = @open_files[text_document.filename]
-      @open_files[text_document.filename] = {text_document, node}
+      original_document, node = @open_files[text_document.filename]
+      if original_document.text != text_document.text
+        put_file(text_document)
+      else
+        @open_files[text_document.filename]
+      end
     end
 
     def drop_file(text_document : TextDocument)

--- a/src/scry/workspace.cr
+++ b/src/scry/workspace.cr
@@ -31,33 +31,29 @@ module Scry
       @open_files[file.filename] = {file, method_db}
     end
 
-    def put_file(params : Protocol::DidOpenTextDocumentParams)
-      file = TextDocument.new(params)
-      if @dependency_graph[file.filename]?
-        file_dependencies = @dependency_graph[file.filename].descendants.map &.value
+    def put_file(text_document : TextDocument)
+      if @dependency_graph[text_document.filename]?
+        file_dependencies = @dependency_graph[text_document.filename].descendants.map &.value
       else
         file_dependencies = @dependency_graph.prelude_node.descendants.map &.value
       end
-      file_dependencies << file.filename
+      file_dependencies << text_document.filename
       method_db = Completion::MethodDB.generate(file_dependencies.uniq!)
-      @open_files[file.filename] = {file, method_db}
+      @open_files[text_document.filename] = {text_document, method_db}
     end
 
-    def update_file(params : Protocol::DidChangeTextDocumentParams)
-      file = TextDocument.new params
-      _, node = @open_files[file.filename]
-      @open_files[file.filename] = {file, node}
+    def update_file(text_document : TextDocument)
+      _, node = @open_files[text_document.filename]
+      @open_files[text_document.filename] = {text_document, node}
     end
 
-    def drop_file(params : Protocol::TextDocumentParams)
-      filename = TextDocument.uri_to_filename(params.text_document.uri)
-      @open_files.delete(filename)
-      @dependency_graph.delete(filename)
+    def drop_file(text_document : TextDocument)
+      @open_files.delete(text_document.filename)
+      @dependency_graph.delete(text_document.filename)
     end
 
-    def get_file(text_document : Protocol::TextDocumentIdentifier)
-      filename = TextDocument.uri_to_filename(text_document.uri)
-      @open_files[filename]
+    def get_file(text_document : TextDocument)
+      @open_files[text_document.filename]
     end
   end
 end


### PR DESCRIPTION
Attempting to clean up some the code.  It seems like we should decouple the Protocol params from the actual Workspace class.  In this case we were passing in the params, and then immediately instantiating a TextDocument, which we already had available prior to calling some of these Workspace methods.  Now we will just pass in a `TextDocument`.  

This also makes me wonder if we should either rename `TextDocument` to something like `SourceFile` or possibly rename the Workspace methods to something like `put_document` just to be consistent.