### PR TITLE
Require json once

### DIFF
--- a/src/scry/protocol.cr
+++ b/src/scry/protocol.cr
@@ -1,1 +1,2 @@
+require "json"
 require "./protocol/*"

--- a/src/scry/protocol/cancel_params.cr
+++ b/src/scry/protocol/cancel_params.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   struct CancelParams
     JSON.mapping({

--- a/src/scry/protocol/did_open_text_document_params.cr
+++ b/src/scry/protocol/did_open_text_document_params.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   struct DidOpenTextDocumentParams
     JSON.mapping({

--- a/src/scry/protocol/file_event.cr
+++ b/src/scry/protocol/file_event.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   enum FileEventType
     Created = 1

--- a/src/scry/protocol/formatting_options.cr
+++ b/src/scry/protocol/formatting_options.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   struct FormattingOptions
     JSON.mapping({

--- a/src/scry/protocol/hover.cr
+++ b/src/scry/protocol/hover.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   struct Hover
     JSON.mapping({

--- a/src/scry/protocol/initialize_params.cr
+++ b/src/scry/protocol/initialize_params.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   struct InitializeParams
     JSON.mapping({

--- a/src/scry/protocol/log_message_params.cr
+++ b/src/scry/protocol/log_message_params.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   struct LogMessageParams
     JSON.mapping({

--- a/src/scry/protocol/markup_content.cr
+++ b/src/scry/protocol/markup_content.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   struct MarkupContent
     JSON.mapping({

--- a/src/scry/protocol/position.cr
+++ b/src/scry/protocol/position.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   struct Position
     JSON.mapping({

--- a/src/scry/protocol/response_error.cr
+++ b/src/scry/protocol/response_error.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   enum ErrorCodes
     # Defined by JSON RPC

--- a/src/scry/protocol/server_capabilities.cr
+++ b/src/scry/protocol/server_capabilities.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   enum TextDocumentSyncKind
     None

--- a/src/scry/protocol/settings.cr
+++ b/src/scry/protocol/settings.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   alias Settings = SettingsCrystalIDE | SettingsCrystalLang
 

--- a/src/scry/protocol/symbol_information.cr
+++ b/src/scry/protocol/symbol_information.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   enum SymbolKind
     File        =  1

--- a/src/scry/protocol/text_document_identifier.cr
+++ b/src/scry/protocol/text_document_identifier.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   struct TextDocumentIdentifier
     JSON.mapping({

--- a/src/scry/protocol/text_document_params.cr
+++ b/src/scry/protocol/text_document_params.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   struct TextDocumentParams
     JSON.mapping({

--- a/src/scry/protocol/trace.cr
+++ b/src/scry/protocol/trace.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   # The initial trace setting. If omitted trace is disabled ('off')
   # 'off' | 'messages' | 'verbose'

--- a/src/scry/protocol/versioned_text_document_identifier.cr
+++ b/src/scry/protocol/versioned_text_document_identifier.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   struct VersionedTextDocumentIdentifier
     JSON.mapping({

--- a/src/scry/protocol/void_params.cr
+++ b/src/scry/protocol/void_params.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   struct VoidParams
     def initialize(pull : JSON::PullParser)

--- a/src/scry/protocol/workspace_symbol_params.cr
+++ b/src/scry/protocol/workspace_symbol_params.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module Scry::Protocol
   struct WorkspaceSymbolParams
     JSON.mapping({


### PR DESCRIPTION
Small cleanup to remove all the `require "json"` littered throughout the Protocol namespace