### PR TITLE
Return request id w/ error response

### DIFF
--- a/src/scry/protocol/response_message.cr
+++ b/src/scry/protocol/response_message.cr
@@ -18,7 +18,7 @@ module Scry::Protocol
     def initialize(@result)
     end
 
-    def initialize(ex : Exception)
+    def initialize(@id, ex : Exception)
       @error = ResponseError.new(
         ex.message || "Unknown error",
         ex.backtrace


### PR DESCRIPTION
Fixes  #52 

Returns the id of the Request with a Response error.  

According to the spec we should not be returning any message for Notifications.