### PR TITLE
Always emit the id property for responses, even if null

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -28,7 +28,7 @@ module Scry
 
   BUILD_ERROR_EXAMPLE = %({"file":"/home/aa.cr","line":4,"column":1,"size":1,"message":"Oh no!, an Error"})
 
-  FORMATTER_RESPONSE_EXAMPLE = %({"jsonrpc":"2.0","result":[{"range":{"start":{"line":0,"character":0},"end":{"line":1,"character":6}},"newText":"1 + 1\\n"}]})
+  FORMATTER_RESPONSE_EXAMPLE = %({"jsonrpc":"2.0","id":null,"result":[{"range":{"start":{"line":0,"character":0},"end":{"line":1,"character":6}},"newText":"1 + 1\\n"}]})
 
   TEXTDOCUMENT_POSITION_PARAM_EXAMPLE = %({"textDocument":{"uri":"#{SOME_FILE_PATH}"},"position":{"line":4,"character":2}})
 

--- a/src/scry/protocol/response_message.cr
+++ b/src/scry/protocol/response_message.cr
@@ -5,7 +5,7 @@ module Scry::Protocol
   struct ResponseMessage
     JSON.mapping({
       jsonrpc: String,
-      id:      Int32 | String | Nil,
+      id:      {type: Int32 | String | Nil, emit_null: true},
       result:  ResponseTypes?,
       error:   ResponseError?,
     }, true)


### PR DESCRIPTION
Fixes #52 
Closes #140 

This might be a more simple solution to fixing #52.  According to the spec we should always emit the id field in a response, even if it is `null`

@bew would you be able to verify this?