### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,25 @@
 
 ### Scry
 
-- Fix formatting untitled file (#65)
-- Analyze files with implicit requires (#80)
-- Change default log level to info (#93)
-- Add workspace symbols (#106)
-- Add symbol end_position using end_location (#114)
-- Do not use File.each_line iterator to ensure Files are closed (#116)
-- Add hover (#107)
-- Log to client (#115)
-- Add class and module name completion (#100)
-- Log response on exception (#123)
+- Fix formatting untitled file [#65](https://github.com/crystal-lang-tools/scry/pull/65)
+- Analyze files with implicit requires [#80](https://github.com/crystal-lang-tools/scry/pull/80)
+- Change default log level to info [#93](https://github.com/crystal-lang-tools/scry/pull/93)
+- Add workspace symbols [#106](https://github.com/crystal-lang-tools/scry/pull/106)
+- Add symbol end_position using end_location [#114](https://github.com/crystal-lang-tools/scry/pull/114)
+- Do not use File.each_line iterator to ensure Files are closed [#116](https://github.com/crystal-lang-tools/scry/pull/116)
+- Add hover [#107](https://github.com/crystal-lang-tools/scry/pull/107)
+- Log to client [#115](https://github.com/crystal-lang-tools/scry/pull/115)
+- Add class and module name completion [#100](https://github.com/crystal-lang-tools/scry/pull/100)
+- Log response on exception [#123](https://github.com/crystal-lang-tools/scry/pull/123)
 - Various other bug fixes/code refactors
 
 ### Protocol
 
-- Handle exit and shutdown request (#76)
-- Fixes InitializeParams to follow LSP specification (#82)
-- Add Protocol namespace (#134)
+- Handle exit and shutdown request [#76](https://github.com/crystal-lang-tools/scry/pull/76)
+- Fixes InitializeParams to follow LSP specification [#82](https://github.com/crystal-lang-tools/scry/pull/82)
+- Add Protocol namespace [#134](https://github.com/crystal-lang-tools/scry/pull/134)
 
 ### CI
 
-- On ci check that code is formatted (#57)
+- On ci check that code is formatted [#57](https://github.com/crystal-lang-tools/scry/pull/57)
 - Update to use latest version of Crystal (v0.27.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+## v0.8.0
+
+### Scry
+
+- Fix formatting untitled file (#65)
+- Analyze files with implicit requires (#80)
+- Change default log level to info (#93)
+- Add workspace symbols (#106)
+- Add symbol end_position using end_location (#114)
+- Do not use File.each_line iterator to ensure Files are closed (#116)
+- Add hover (#107)
+- Log to client (#115)
+- Add class and module name completion (#100)
+- Log response on exception (#123)
+- Various other bug fixes/code refactors
+
+### Protocol
+
+- Handle exit and shutdown request (#76)
+- Fixes InitializeParams to follow LSP specification (#82)
+- Add Protocol namespace (#134)
+
+### CI
+
+- On ci check that code is formatted (#57)
+- Update to use latest version of Crystal (v0.27.0)


### PR DESCRIPTION
Adds a CHANGELOG.md is preparation for `v0.8.0` release  I tried to just add the major changes since it has been awhile since a there has been a Scry release.