### PR TITLE
Make it clear that Message is a factory

### DIFF
--- a/spec/protocol_helper.cr
+++ b/spec/protocol_helper.cr
@@ -21,7 +21,7 @@ module Scry
     end
 
     def test_send(message)
-      dispatch(Message.new(message).parse)
+      dispatch(Message.from(message))
     end
   end
 end

--- a/spec/scry/context_spec.cr
+++ b/spec/scry/context_spec.cr
@@ -5,23 +5,23 @@ module Scry
     it "dispatches commands" do
       context = Context.new
 
-      procedure = Message.new(INITIALIZATION_EXAMPLE).parse
+      procedure = Message.from(INITIALIZATION_EXAMPLE)
       result = context.dispatch(procedure)
       result.is_a?(Protocol::Initialize).should be_true
 
-      procedure = Message.new(CONFIG_CHANGE_EXAMPLE).parse
+      procedure = Message.from(CONFIG_CHANGE_EXAMPLE)
       context.dispatch(procedure)
 
-      procedure = Message.new(DOC_OPEN_EXAMPLE).parse
+      procedure = Message.from(DOC_OPEN_EXAMPLE)
       context.dispatch(procedure)
 
-      procedure = Message.new(DOC_CHANGE_EXAMPLE).parse
+      procedure = Message.from(DOC_CHANGE_EXAMPLE)
       context.dispatch(procedure)
 
-      procedure = Message.new(WATCHED_FILE_CHANGED_EXAMPLE).parse
+      procedure = Message.from(WATCHED_FILE_CHANGED_EXAMPLE)
       context.dispatch(procedure)
 
-      procedure = Message.new(WATCHED_FILE_DELETED_EXAMPLE).parse
+      procedure = Message.from(WATCHED_FILE_DELETED_EXAMPLE)
       result = context.dispatch(procedure)
       result.to_json.should eq(%([[{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file://#{SOME_FILE_PATH}","diagnostics":[]}}]]))
     end

--- a/spec/scry/message_spec.cr
+++ b/spec/scry/message_spec.cr
@@ -3,37 +3,37 @@ require "../spec_helper"
 module Scry
   describe Message do
     it "creates an initialization request" do
-      procedure = Message.new(INITIALIZATION_EXAMPLE).parse
+      procedure = Message.from(INITIALIZATION_EXAMPLE)
       procedure.is_a?(Protocol::RequestMessage).should be_true
     end
 
     it "creates configuration change request" do
-      procedure = Message.new(CONFIG_CHANGE_EXAMPLE).parse
+      procedure = Message.from(CONFIG_CHANGE_EXAMPLE)
       procedure.is_a?(Protocol::NotificationMessage).should be_true
     end
 
     it "creates a document opened request" do
-      procedure = Message.new(DOC_OPEN_EXAMPLE).parse
+      procedure = Message.from(DOC_OPEN_EXAMPLE)
       procedure.is_a?(Protocol::NotificationMessage).should be_true
     end
 
     it "handles no-argument procedure calls" do
-      procedure = Message.new(SHUTDOWN_EXAMPLE).parse
+      procedure = Message.from(SHUTDOWN_EXAMPLE)
       procedure.is_a?(Protocol::RequestMessage).should be_true
     end
 
     it "creates a didSave notification" do
-      procedure = Message.new(DID_SAVE_EXAMPLE).parse
+      procedure = Message.from(DID_SAVE_EXAMPLE)
       procedure.is_a?(Protocol::NotificationMessage).should be_true
     end
 
     it "creates a didClose notification" do
-      procedure = Message.new(DOC_CLOSE_EXAMPLE).parse
+      procedure = Message.from(DOC_CLOSE_EXAMPLE)
       procedure.is_a?(Protocol::NotificationMessage).should be_true
     end
 
     it "creates a initialized notification" do
-      procedure = Message.new(INITIALIZED_EXAMPLE).parse
+      procedure = Message.from(INITIALIZED_EXAMPLE)
       procedure.is_a?(Protocol::NotificationMessage).should be_true
     end
   end

--- a/src/scry.cr
+++ b/src/scry.cr
@@ -23,7 +23,7 @@ module Scry
     loop do
       begin
         content = Request.new(STDIN).read
-        request = Message.new(content).parse
+        request = Message.from(content)
         results = context.dispatch(request)
       rescue ex
         results = [Protocol::ResponseMessage.new(ex)]

--- a/src/scry/message.cr
+++ b/src/scry/message.cr
@@ -4,7 +4,7 @@ module Scry
 
   alias ProtocolMessage = Protocol::RequestMessage | Protocol::NotificationMessage
 
-  struct Message
+  module Message
     def self.from(json : String?)
       raise InvalidContentError.new("Expected procedure content") unless json
       

--- a/src/scry/message.cr
+++ b/src/scry/message.cr
@@ -5,15 +5,10 @@ module Scry
   alias ProtocolMessage = Protocol::RequestMessage | Protocol::NotificationMessage
 
   struct Message
-    def initialize(@json : String)
-    end
-
-    def initialize(@json : Nil)
-      raise InvalidContentError.new("Expected procedure content")
-    end
-
-    def parse
-      ProtocolMessage.from_json(@json || "")
+    def self.from(json : String?)
+      raise InvalidContentError.new("Expected procedure content") unless json
+      
+      ProtocolMessage.from_json(json)
     end
   end
 end

--- a/src/scry/message.cr
+++ b/src/scry/message.cr
@@ -7,7 +7,7 @@ module Scry
   module Message
     def self.from(json : String?)
       raise InvalidContentError.new("Expected procedure content") unless json
-      
+
       ProtocolMessage.from_json(json)
     end
   end


### PR DESCRIPTION
Came across this repo when I was looking for something in Crystal to contribute to and I thought I'd dive in.  Starting from the beginning I noticed this `Message` class that was being initialized and `#parse` immediately called in all cases.  Seeing how the JSON was being handled was definitely interesting but I believe that the `Message` class would be more clear if there was just the one, class-level method.

Looking back at the history I see that this `Message.new(...).parse` is from the [very first commit](https://github.com/crystal-lang-tools/scry/commit/dffefb00e38fcb045252fcd3819cf8a7e1ba12a9?short_path=04c6e90#diff-62f71642256d6493b5a748976dc28bdaR28) when it was still called `Procedure`.

Hope to be able to contribute more soon!