### PR TITLE
textDocument/definition shortcut if local require

### DIFF
--- a/src/scry/protocol/response_message.cr
+++ b/src/scry/protocol/response_message.cr
@@ -1,6 +1,6 @@
 module Scry::Protocol
   # Add a response type when needed
-  alias ResponseTypes = Array(TextEdit) | Array(Location) | Array(SymbolInformation) | Array(CompletionItem) | CompletionItem | Hover
+  alias ResponseTypes = Array(TextEdit) | Array(Location) | Array(SymbolInformation) | Array(CompletionItem) | CompletionItem | Hover | Location
 
   struct ResponseMessage
     JSON.mapping({

--- a/src/scry/text_document.cr
+++ b/src/scry/text_document.cr
@@ -81,6 +81,11 @@ module Scry
       @text.first
     end
 
+    def get_line(line_number)
+      lines = source.split("\n")
+      lines[line_number]
+    end
+
     private def read_file : String
       File.read(filename)
     rescue ex : IO::Error


### PR DESCRIPTION
If the selection is a local require, the path can be build manually.

current file is `/home/src/main.cr` and require is:
```crystal
require "./api/controller"
```
then the path to the definition is just `/home/src/api/controller.cr` unless I'm missing something.

---

I have made the same PR on vscode plugin as well. https://github.com/crystal-lang-tools/vscode-crystal-lang/pull/78