### PR TITLE
textDocument/definition shortcut if local require

### DIFF
--- a/src/scry/implementations.cr
+++ b/src/scry/implementations.cr
@@ -41,8 +41,8 @@ module Scry
     end
 
     LOCAL_REQUIRE_REGEX = /^require\s+"(\.{1,2}.*?)"\s*$/
-    POSITION_0 = Protocol::Position.new(0, 0)
-    RANGE_0 = Protocol::Range.new(POSITION_0, POSITION_0)
+    POSITION_0          = Protocol::Position.new(0, 0)
+    RANGE_0             = Protocol::Range.new(POSITION_0, POSITION_0)
 
     private def get_local_require(filename, position)
       line = @text_document.get_line(position.line)

--- a/src/scry/protocol/response_message.cr
+++ b/src/scry/protocol/response_message.cr
@@ -1,6 +1,6 @@
 module Scry::Protocol
   # Add a response type when needed
-  alias ResponseTypes = Array(TextEdit) | Array(Location) | Array(SymbolInformation) | Array(CompletionItem) | CompletionItem | Hover
+  alias ResponseTypes = Array(TextEdit) | Array(Location) | Array(SymbolInformation) | Array(CompletionItem) | CompletionItem | Hover | Location
 
   struct ResponseMessage
     JSON.mapping({

--- a/src/scry/text_document.cr
+++ b/src/scry/text_document.cr
@@ -81,6 +81,11 @@ module Scry
       @text.first
     end
 
+    def get_line(line_number)
+      lines = source.split("\n")
+      lines[line_number]
+    end
+
     private def read_file : String
       File.read(filename)
     rescue ex : IO::Error

--- a/src/scry/text_document.cr
+++ b/src/scry/text_document.cr
@@ -82,8 +82,8 @@ module Scry
     end
 
     def get_line(line_number)
-      lines = source.split("\n")
-      lines[line_number]
+      line = source.each_line.skip(line_number - 1).next
+      line.is_a?(String) ? line : nil
     end
 
     private def read_file : String


### PR DESCRIPTION
If the selection is a local require, the path can be built manually.

current file is `/home/src/main.cr` and require is:
```crystal
require "./api/controller"
```
then the path to the definition is just `/home/src/api/controller.cr` unless I'm missing something.

Also includes logic to make sure the selection is within the quotation marks.

[Benchmark says this is at least 200x faster for local requires:](https://github.com/matthewmcgarvey/scry/tree/local-require-benchmark)

<img width="442" alt="screen shot 2019-01-18 at 10 36 00 pm" src="https://user-images.githubusercontent.com/17329408/51422332-74b8ca80-1b72-11e9-921f-644e0ff4a13e.png">


---

I have made the same PR on vscode plugin as well. https://github.com/crystal-lang-tools/vscode-crystal-lang/pull/78