### PR TITLE
Add support for annotations

### DIFF
--- a/spec/scry/symbol_spec.cr
+++ b/spec/scry/symbol_spec.cr
@@ -57,29 +57,29 @@ module Scry
       result.kind.should be_a(LSP::Protocol::SymbolKind::Property)
     end
 
-    describe "Property" do
-      it "returns getters as Property symbols" do
+    describe "Variable" do
+      it "returns getters as Variable symbols" do
         text_document = TextDocument.new("uri", ["class Foo; getter bar : Nil; end"])
         processor = SymbolProcessor.new(text_document)
         symbols = processor.run
         result = symbols[1]
-        result.kind.should be_a(LSP::Protocol::SymbolKind::Property)
+        result.kind.should be_a(LSP::Protocol::SymbolKind::Variable)
       end
 
-      it "returns setters as Property symbols" do
+      it "returns setters as Variable symbols" do
         text_document = TextDocument.new("uri", ["class Foo; setter bar : Nil; end"])
         processor = SymbolProcessor.new(text_document)
         symbols = processor.run
         result = symbols[1]
-        result.kind.should be_a(LSP::Protocol::SymbolKind::Property)
+        result.kind.should be_a(LSP::Protocol::SymbolKind::Variable)
       end
 
-      it "returns properties as Property symbols" do
+      it "returns properties as Variable symbols" do
         text_document = TextDocument.new("uri", ["class Foo; property bar : Nil; end"])
         processor = SymbolProcessor.new(text_document)
         symbols = processor.run
         result = symbols[1]
-        result.kind.should be_a(LSP::Protocol::SymbolKind::Property)
+        result.kind.should be_a(LSP::Protocol::SymbolKind::Variable)
       end
     end
 

--- a/spec/scry/symbol_spec.cr
+++ b/spec/scry/symbol_spec.cr
@@ -49,6 +49,14 @@ module Scry
       result.kind.should be_a(LSP::Protocol::SymbolKind::Variable)
     end
 
+    it "returns annotation as Property symbols" do
+      text_document = TextDocument.new("uri", ["annotation Test; end"])
+      processor = SymbolProcessor.new(text_document)
+      symbols = processor.run
+      result = symbols.first
+      result.kind.should be_a(LSP::Protocol::SymbolKind::Property)
+    end
+
     describe "Property" do
       it "returns getters as Property symbols" do
         text_document = TextDocument.new("uri", ["class Foo; getter bar : Nil; end"])

--- a/spec/scry/symbol_spec.cr
+++ b/spec/scry/symbol_spec.cr
@@ -14,7 +14,7 @@ module Scry
       processor = SymbolProcessor.new(text_document)
       symbols = processor.run
       result = symbols.first
-      result.kind.should be_a(LSP::Protocol::SymbolKind::Class)
+      result.kind.should eq(LSP::Protocol::SymbolKind::Class)
     end
 
     it "returns Struct symbols as a Class" do
@@ -22,7 +22,7 @@ module Scry
       processor = SymbolProcessor.new(text_document)
       symbols = processor.run
       result = symbols.first
-      result.kind.should be_a(LSP::Protocol::SymbolKind::Class)
+      result.kind.should eq(LSP::Protocol::SymbolKind::Class)
     end
 
     it "returns Module symbols" do
@@ -30,7 +30,7 @@ module Scry
       processor = SymbolProcessor.new(text_document)
       symbols = processor.run
       result = symbols.first
-      result.kind.should be_a(LSP::Protocol::SymbolKind::Module)
+      result.kind.should eq(LSP::Protocol::SymbolKind::Module)
     end
 
     it "returns Method symbols" do
@@ -38,7 +38,7 @@ module Scry
       processor = SymbolProcessor.new(text_document)
       symbols = processor.run
       result = symbols.first
-      result.kind.should be_a(LSP::Protocol::SymbolKind::Method)
+      result.kind.should eq(LSP::Protocol::SymbolKind::Method)
     end
 
     it "returns instance vars as Variable symbols" do
@@ -46,7 +46,7 @@ module Scry
       processor = SymbolProcessor.new(text_document)
       symbols = processor.run
       result = symbols.first
-      result.kind.should be_a(LSP::Protocol::SymbolKind::Variable)
+      result.kind.should eq(LSP::Protocol::SymbolKind::Variable)
     end
 
     it "returns annotation as Property symbols" do
@@ -54,7 +54,7 @@ module Scry
       processor = SymbolProcessor.new(text_document)
       symbols = processor.run
       result = symbols.first
-      result.kind.should be_a(LSP::Protocol::SymbolKind::Property)
+      result.kind.should eq(LSP::Protocol::SymbolKind::Property)
     end
 
     describe "Variable" do
@@ -63,7 +63,7 @@ module Scry
         processor = SymbolProcessor.new(text_document)
         symbols = processor.run
         result = symbols[1]
-        result.kind.should be_a(LSP::Protocol::SymbolKind::Variable)
+        result.kind.should eq(LSP::Protocol::SymbolKind::Variable)
       end
 
       it "returns setters as Variable symbols" do
@@ -71,7 +71,7 @@ module Scry
         processor = SymbolProcessor.new(text_document)
         symbols = processor.run
         result = symbols[1]
-        result.kind.should be_a(LSP::Protocol::SymbolKind::Variable)
+        result.kind.should eq(LSP::Protocol::SymbolKind::Variable)
       end
 
       it "returns properties as Variable symbols" do
@@ -79,7 +79,7 @@ module Scry
         processor = SymbolProcessor.new(text_document)
         symbols = processor.run
         result = symbols[1]
-        result.kind.should be_a(LSP::Protocol::SymbolKind::Variable)
+        result.kind.should eq(LSP::Protocol::SymbolKind::Variable)
       end
     end
 
@@ -89,7 +89,7 @@ module Scry
         processor = SymbolProcessor.new(text_document)
         symbols = processor.run
         result = symbols.first
-        result.kind.should be_a(LSP::Protocol::SymbolKind::Constant)
+        result.kind.should eq(LSP::Protocol::SymbolKind::Constant)
       end
 
       it "returns alias as Constant symbols" do
@@ -97,7 +97,7 @@ module Scry
         processor = SymbolProcessor.new(text_document)
         symbols = processor.run
         result = symbols.first
-        result.kind.should be_a(LSP::Protocol::SymbolKind::Constant)
+        result.kind.should eq(LSP::Protocol::SymbolKind::Constant)
       end
     end
 
@@ -112,14 +112,14 @@ module Scry
         processor = WorkspaceSymbolProcessor.new(ROOT_PATH, "saluto")
         symbols = processor.run
         result = symbols.first
-        result.kind.should be_a(LSP::Protocol::SymbolKind::Method)
+        result.kind.should eq(LSP::Protocol::SymbolKind::Method)
       end
 
       it "return stdlib symbol with query match for initialize" do
         processor = WorkspaceSymbolProcessor.new(ROOT_PATH, "initialize")
         symbols = processor.run
         result = symbols.first
-        result.kind.should be_a(LSP::Protocol::SymbolKind::Method)
+        result.kind.should eq(LSP::Protocol::SymbolKind::Method)
       end
     end
   end

--- a/src/scry/symbol.cr
+++ b/src/scry/symbol.cr
@@ -44,6 +44,12 @@ module Scry
       true
     end
 
+    def visit(node : Crystal::AnnotationDef)
+      process_node node, node.name.names.last, LSP::Protocol::SymbolKind::Property
+      @container << node.name.names.last
+      true
+    end
+
     def visit(node : Crystal::FunDef)
       process_node node, node.name, LSP::Protocol::SymbolKind::Function
       true
@@ -79,7 +85,7 @@ module Scry
       true
     end
 
-    def end_visit(node : Crystal::ClassDef | Crystal::ModuleDef | Crystal::CStructOrUnionDef | Crystal::LibDef | Crystal::EnumDef)
+    def end_visit(node : Crystal::ClassDef | Crystal::ModuleDef | Crystal::CStructOrUnionDef | Crystal::LibDef | Crystal::EnumDef | Crystal::AnnotationDef)
       return unless node.location
       @container.pop?
     end

--- a/src/scry/symbol.cr
+++ b/src/scry/symbol.cr
@@ -76,7 +76,7 @@ module Scry
     end
 
     def visit(node : Crystal::Var)
-      process_node node, node.name, LSP::Protocol::SymbolKind::Property
+      process_node node, node.name, LSP::Protocol::SymbolKind::Variable
       true
     end
 


### PR DESCRIPTION
Adds support for parsing of user-defined annotations (crystal-lang/crystal#6063).

I'm not overly familiar with this code base to apologies if I've butchered the implementation. Any suggestions / criticism / (constructive) abuse welcomed in the thread here prior merge.

Updated specs are passing and the build output is tested and running within [crystal-lang-tools/atom-ide-crystal](https://github.com/crystal-lang-tools/atom-ide-crystal).