### PR TITLE
Add --release flag to install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ To install Scry download it from the [releases page](https://github.com/crystal-
 ```bash
 git clone https://github.com/crystal-lang-tools/scry.git
 cd scry
-shards build -v
+shards build --verbose --release
 ```
 
-Then setup `scry` binary path on your LSP client.
+Then, set your LSP client's `scry` binary path to point to `scry/bin/scry`.
 
 ## Known issues
 


### PR DESCRIPTION
It's quite possible that I missed something. But, if not, the default installation instructions do not build ```release``` versions and take, according to some crude benchmarking, 5x longer than necessary?

```
# crystal spec spec/scry/parse_analyzer_spec.cr
3364 files, time is   5.254480   0.124605   5.379085 (  5.311287)
```

```
# crystal spec  --release spec/scry/parse_analyzer_spec.cr
Benchmarking: 3364 files, time is   0.916777   0.109408   1.026185 (  0.963096)
```