### PR TITLE
Remove the usage of Errno since it is now enum

### DIFF
--- a/src/scry/text_document.cr
+++ b/src/scry/text_document.cr
@@ -92,10 +92,7 @@ module Scry
 
     private def read_file : String
       File.read(filename)
-    rescue ex : IO::Error
-      Log.logger.warn(ex.message)
-      ""
-    rescue ex : Errno
+    rescue ex : Exception
       Log.logger.warn(ex.message)
       ""
     end


### PR DESCRIPTION
Crystal has the new hierarchy of the new or updated exceptions.

Exception now has an optional os_error containing the original error code that anyone can use in case the exception class hierarchy is not enough for proper error handling.

Errno and Winerror are now enums.