### PR TITLE
Fix compatibility for Crystal 0.35.0

### DIFF
--- a/src/scry/environment_config.cr
+++ b/src/scry/environment_config.cr
@@ -1,6 +1,6 @@
 module Scry
   module EnvironmentConfig
-    private enum EnvVars
+    enum EnvVars
       CRYSTAL_CACHE_DIR
       CRYSTAL_PATH
       CRYSTAL_VERSION

--- a/src/scry/environment_config.cr
+++ b/src/scry/environment_config.cr
@@ -1,22 +1,29 @@
 module Scry
   module EnvironmentConfig
+    private enum EnvVars
+      CRYSTAL_CACHE_DIR
+      CRYSTAL_PATH
+      CRYSTAL_VERSION
+      CRYSTAL_LIBRARY_PATH
+      CRYSTAL_OPTS
+    end
+
     def self.run
-      initialize_from_crystal_env.each do |k, v|
-        ENV[k] = v
+      initialize_from_crystal_env.each_with_index do |v, i|
+        e = EnvVars.from_value(i).to_s
+        ENV[e] = v
       end
     end
 
     private def self.initialize_from_crystal_env
       crystal_env
         .lines
-        .map(&.split('='))
-        .map { |(k, v)| {k, v.chomp[1..-2]} }
-        .to_h
+        .to_a
     end
 
     private def self.crystal_env
       String.build do |io|
-        Process.run("crystal", ["env"], output: io)
+        Process.run("crystal", ["env"] + EnvVars.names, output: io)
       end
     end
   end


### PR DESCRIPTION
Due to change of quoting environment variables in crystal compiler crystal-lang/crystal/pull/9428 Scry interpreted them erroneously causing #173 and creating compiler's cache files in wrong location.

Fixes #173 