### PR TITLE
Follow crystal 0.36.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.34.0
+FROM crystallang/crystal:0.36.1-build
 
 RUN apt-get update
 RUN apt-get clean

--- a/shard.lock
+++ b/shard.lock
@@ -1,6 +1,10 @@
-version: 1.0
+version: 2.0
 shards:
-  lsp:
-    github: crystal-lang-tools/lsp
+  json_mapping:
+    git: https://github.com/crystal-lang/json_mapping.cr.git
     version: 0.1.0
+
+  lsp:
+    git: https://github.com/kachick/lsp.git
+    version: 0.1.0+git.commit.ea568acc53956a691f44a6e9305db0e829c48c45
 

--- a/shard.yml
+++ b/shard.yml
@@ -10,7 +10,11 @@ targets:
   scry:
     main: src/scry.cr
 
+crystal: ">= 0.36.1"
+
 dependencies:
   lsp:
-    github: crystal-lang-tools/lsp
+    # Workaround repository and branch. Use `master` branch of `crystal-lang-tools/lsp` after merging https://github.com/crystal-lang-tools/lsp/pull/6
+    github: kachick/lsp
+    branch: follow-crystal-0361
     version: 0.1.0

--- a/src/scry/hover_provider.cr
+++ b/src/scry/hover_provider.cr
@@ -70,14 +70,14 @@ module Scry
     #
     # **Context 1**
     #
-    # ```crystal
+    # ```
     # arg1 : String
     # arg2 : Int32 ∣ Nil
     # ```
     #
     # **Context 2**
     #
-    # ```crystal
+    # ```
     # arg1 : String
     # arg2 : Bool
     # ```

--- a/src/scry/log.cr
+++ b/src/scry/log.cr
@@ -14,7 +14,7 @@ module Scry
       message_type = case entry.severity
                      when ::Log::Severity::Info
                        LSP::Protocol::MessageType::Info
-                     when ::Log::Severity::Warning
+                     when ::Log::Severity::Warn
                        LSP::Protocol::MessageType::Warning
                      when ::Log::Severity::Error, ::Log::Severity::Fatal
                        LSP::Protocol::MessageType::Error

--- a/src/scry/parse_analyzer.cr
+++ b/src/scry/parse_analyzer.cr
@@ -19,7 +19,7 @@ module Scry
       parser.filename = @text_document.filename
       parser.parse
       [@diagnostic.clean]
-    rescue ex : Crystal::Exception
+    rescue ex : Crystal::CodeError
       @diagnostic.from(ex.to_json)
     end
   end

--- a/src/scry/update_config.cr
+++ b/src/scry/update_config.cr
@@ -7,8 +7,8 @@ module Scry
     LOG_LEVELS = {
       "debug"   => ::Log::Severity::Debug,
       "info"    => ::Log::Severity::Info,
-      "warn"    => ::Log::Severity::Warning,
-      "warning" => ::Log::Severity::Warning,
+      "warn"    => ::Log::Severity::Warn,
+      "warning" => ::Log::Severity::Warn,
       "error"   => ::Log::Severity::Error,
       "fatal"   => ::Log::Severity::Fatal,
     }


### PR DESCRIPTION
I don't know the detail of the language specs and changing history of crystal. So I guess this PR does not actually support latest language specs.
But currently we can't even finish running tests in crystal 0.36.1. So this PR just fixes them.

Fixes https://github.com/crystal-lang-tools/scry/issues/179

Refs
---

* https://github.com/crystal-lang-tools/lsp/pull/6
* https://github.com/crystal-lang/crystal/pull/9527
* https://github.com/crystal-lang/crystal/pull/9293
* https://github.com/crystal-lang/crystal/pull/10197