### PR TITLE
[WIP] Follow latest Homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
         - DEPLOY_DIR=bin/linux
         - DEPLOY_STATIC="--static"
     - os: osx
+      osx_image: xcode12.2
       env:
         - DEPLOY_FILENAME=scry_macOS.tar.gz
         - DEPLOY_DIR=bin/darwin
@@ -28,7 +29,7 @@ after_success:
 notifications:
   webhooks:
     urls:
-    - https://webhooks.gitter.im/e/94bc44167f5a3d9fa7a8
+      - https://webhooks.gitter.im/e/94bc44167f5a3d9fa7a8
     on_success: change
     on_failure: always
     on_start: never


### PR DESCRIPTION
Current CI looks 🔴 https://travis-ci.org/github/crystal-lang-tools/scry/builds/761829382

I guess it came from Travis-CI supported old MacOS as the default...

https://github.com/Homebrew/discussions/discussions/461#discussioncomment-266166
https://docs.travis-ci.com/user/reference/osx/#macos-version

Current latest is below

<img width="849" alt="スクリーンショット 2021-03-08 3 22 51" src="https://user-images.githubusercontent.com/1180335/110250243-9b8a2300-7fbd-11eb-942d-2fcd1751aae8.png">


